### PR TITLE
JSON emitter

### DIFF
--- a/src/bmeg/models/edge_models.py
+++ b/src/bmeg/models/edge_models.py
@@ -19,23 +19,6 @@ class Edge:
     def make_gid(cls, from_gid, to_gid):
         return "(%s)--%s->(%s)" % (from_gid, cls.__name__, to_gid)
 
-    def dump(self):
-        if not self.gid:
-            raise ValueError("gid is empty")
-
-        data = dict(self.__dict__)
-        del data["gid"]
-        del data["from_gid"]
-        del data["to_gid"]
-
-        return json.dumps({
-            "gid": self.gid,
-            "label": self.__class__.__name__,
-            "from": self.from_gid,
-            "to": self.to_gid,
-            "data": data
-        })
-
 
 @dataclass(frozen=True)
 class VariantIn(Edge):

--- a/src/bmeg/models/emitter.py
+++ b/src/bmeg/models/emitter.py
@@ -1,3 +1,4 @@
+import atexit
 import json
 import bson
 import msgpack
@@ -131,6 +132,7 @@ class filehandler:
         self.extension = extension
         self.mode = mode
         self.handles = {}
+        atexit.register(self.close)
 
     def __getitem__(self, obj):
         label = obj.__class__.__name__

--- a/src/bmeg/models/emitter.py
+++ b/src/bmeg/models/emitter.py
@@ -6,6 +6,18 @@ import os
 from bmeg.models.vertex_models import Vertex
 from bmeg.models.edge_models import Edge
 
+
+class DebugEmitter:
+    def __init__(self, **kwargs):
+        self.emitter = emitter(**kwargs)
+
+    def close(self):
+        return
+
+    def emit(self, obj):
+        d = self.emitter.emit(obj)
+        print(json.dumps(d, indent=True))
+
 class MsgpackEmitter:
     def __init__(self, prefix, **kwargs):
         self.handles = filehandler(prefix, "msgp", mode="wb")

--- a/src/bmeg/models/emitter.py
+++ b/src/bmeg/models/emitter.py
@@ -1,13 +1,44 @@
 import json
+import bson
+import msgpack
 import os
 
 from bmeg.models.vertex_models import Vertex
 from bmeg.models.edge_models import Edge
 
+class MsgpackEmitter:
+    def __init__(self, prefix, **kwargs):
+        self.handles = filehandler(prefix, "msgp", mode="wb")
+        self.emitter = emitter(**kwargs)
+
+    def close(self):
+        self.handles.close()
+
+    def emit(self, obj):
+        d = self.emitter.emit(obj)
+        fh = self.handles[obj]
+        b = msgpack.dumps(d)
+        fh.write(b)
+        #fh.write(os.linesep)
+
+class BSONEmitter:
+    def __init__(self, prefix, **kwargs):
+        self.handles = filehandler(prefix, "bson", mode="wb")
+        self.emitter = emitter(**kwargs)
+
+    def close(self):
+        self.handles.close()
+
+    def emit(self, obj):
+        d = self.emitter.emit(obj)
+        fh = self.handles[obj]
+        b = bson.dumps(d)
+        fh.write(b)
+        #fh.write(os.linesep)
 
 class JSONEmitter:
     def __init__(self, prefix, **kwargs):
-        self.handles = filehandler(prefix)
+        self.handles = filehandler(prefix, "json")
         self.emitter = emitter(**kwargs)
 
     def close(self):
@@ -50,14 +81,14 @@ class emitter:
             del data["to_gid"]
 
         # delete null values
-        if not self.preserve_nulls:
+        if not self.preserve_null:
             remove = [k for k in data if data[k] is None]
             for k in remove:
                 del data[k]
 
         if isinstance(obj, Vertex):
             dumped = {
-                "gid": self.gid,
+                "gid": obj.gid,
                 "label": label,
                 "data": data
             }
@@ -83,11 +114,13 @@ class filehandler:
 
     This is an internal helper.
     """
-    def __init__(self, prefix):
+    def __init__(self, prefix, extension, mode="w"):
         self.prefix = prefix
+        self.extension = extension
+        self.mode = mode
         self.handles = {}
 
-    def __get__(self, obj):
+    def __getitem__(self, obj):
         label = obj.__class__.__name__
 
         if isinstance(obj, Vertex):
@@ -97,12 +130,12 @@ class filehandler:
         else:
             suffix = "Unknown"
 
-        fname = "%s.%s.%s.json" % (self.prefix, label, suffix)
+        fname = "%s.%s.%s.%s" % (self.prefix, label, suffix, self.extension)
 
         if fname in self.handles:
             return self.handles[fname]
         else:
-            fh = open(fname, "w")
+            fh = open(fname, self.mode)
             self.handles[fname] = fh
             return fh
         

--- a/src/bmeg/models/emitter.py
+++ b/src/bmeg/models/emitter.py
@@ -1,8 +1,10 @@
 import atexit
+from datetime import datetime
 import json
 import bson
 import msgpack
 import os
+import sys
 
 from bmeg.models.vertex_models import Vertex
 from bmeg.models.edge_models import Edge
@@ -64,6 +66,25 @@ class JSONEmitter:
         fh.write(os.linesep)
 
 
+class rate:
+    def __init__(self):
+        self.i = 0
+        self.start = None
+
+    def tick(self):
+        if self.start is None:
+            self.start = datetime.now()
+
+        self.i += 1
+
+        if self.i % 1000 == 0:
+            dt = datetime.now() - self.start
+            self.start = datetime.now()
+            rate = 1000 / dt.total_seconds()
+            m = "rate: {0} emitted ({1:d}/sec)".format(self.i, int(rate))
+            print("\r" + m, end='', file=sys.stderr)
+
+
 class emitter:
     """
     emitter is an internal helper that contains code shared by all emitters,
@@ -72,6 +93,7 @@ class emitter:
 
     def __init__(self, preserve_null=False):
         self.preserve_null = preserve_null
+        self.rate = rate()
 
     def emit(self, obj):
 
@@ -116,6 +138,7 @@ class emitter:
                 "data": data
             }
 
+        self.rate.tick()
         return dumped
 
 

--- a/src/bmeg/models/emitter.py
+++ b/src/bmeg/models/emitter.py
@@ -1,17 +1,25 @@
+import json
+import os
+
 from bmeg.models.vertex_models import Vertex
 from bmeg.models.edge_models import Edge
 
 
 class Emitter:
-    def __init__(self, prefix):
+    def __init__(self, prefix, preserve_null=False):
         self.prefix = prefix
         self.handles = {}
+        self.preserve_null = preserve_null
 
     def close(self):
         for fname, fh in self.handles.items():
             fh.close()
 
     def emit(self, obj):
+
+        if not obj.gid:
+            raise ValueError("gid is empty")
+
         label = obj.__class__.__name__
 
         if isinstance(obj, Vertex):
@@ -29,6 +37,41 @@ class Emitter:
             fh = open(fname, "w")
             self.handles[fname] = fh
 
-        fh.write(obj.dump())
-        fh.write("\n")
+        data = dict(obj.__dict__)
+
+        if "gid" in data:
+            del data["gid"]
+
+        if "from_gid" in data:
+            del data["from_gid"]
+
+        if "to_gid" in data:
+            del data["to_gid"]
+
+        # delete null values
+        if not self.preserve_nulls:
+            remove = [k for k in data if data[k] is None]
+            for k in remove:
+                del data[k]
+
+        if isinstance(obj, Vertex):
+            dumped = json.dumps({
+                "gid": self.gid,
+                "label": label,
+                "data": data
+            })
+
+        elif isinstance(obj, Edge):
+            suffix = "Edge"
+            dumped = json.dumps({
+                "gid": obj.gid,
+                "label": label,
+                "from": obj.from_gid,
+                "to": obj.to_gid,
+                "data": data
+            })
+
+        fh.write(dumped)
+        fh.write(os.linesep)
+
         return

--- a/src/bmeg/models/vertex_models.py
+++ b/src/bmeg/models/vertex_models.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 
 from dataclasses import dataclass, field
 
@@ -10,19 +9,6 @@ from bmeg.models.utils import set_gid
 @dataclass(frozen=True)
 class Vertex:
     gid: GID = field(init=False)
-
-    def dump(self):
-        if not self.gid:
-            raise ValueError("gid is empty")
-
-        data = dict(self.__dict__)
-        del data["gid"]
-
-        return json.dumps({
-            "gid": self.gid,
-            "label": self.__class__.__name__,
-            "data": data
-        })
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
It's usually considered best practice for an emitter to take responsibility of the output format. Currently, we have the responsibility split into multiple places: Vertex.dump, Edge.dump, Emitter.emit. This PR moves all that code into Emitter.emit. I also split out some of the pieces into helpers, which might be reused.

I've also included Emitter-related items I've seen in recent PRs, such as using `os.linesep` and `preserve_nulls`.

I included a couple dumb examples for BSON and Msgpack to show the potential, but more interesting ideas include:
- writing directly to mongo or the graph db
- including more ratify-style validation
- random subsampling output as a debugging tool
- writing a pandas table, CSV, parquet file, etc.

