### PR TITLE
ccle: demo of transforming expression

### DIFF
--- a/src/bmeg/vertex.py
+++ b/src/bmeg/vertex.py
@@ -214,7 +214,8 @@ class Individual(Vertex):
 @dataclass(frozen=True)
 class Biosample(Vertex):
     biosample_id: str
-    gdc_attributes: dict
+    gdc_attributes: dict = None
+    ccle_attributes: dict = None
 
     def gid(self):
         return Individual.make_gid(self.biosample_id)
@@ -222,3 +223,20 @@ class Biosample(Vertex):
     @classmethod
     def make_gid(cls, biosample_id):
         return GID("%s:%s" % (cls.__name__, biosample_id))
+
+
+@enforce_types
+@dataclass(frozen=True)
+class Expression(Vertex):
+    # TODO not just gene, but "feature"
+    gene_id: str
+    sample_id: str
+    scale: str
+    value: float
+
+    def gid(self):
+        return Expression.make_gid(self.gene_id)
+
+    @classmethod
+    def make_gid(cls, gene_id):
+        return GID("%s:%s" % (cls.__name__, gene_id))

--- a/transform/ccle/expression.py
+++ b/transform/ccle/expression.py
@@ -1,0 +1,64 @@
+from collections import defaultdict
+import csv
+import re
+
+from bmeg import vertex, emitter
+from bmeg.util import cli, logging
+
+def transform(emitter):
+    f = open("data/CCLE_DepMap_18q3_RNAseq_RPKM_20180718.gct")
+
+    # Skip GCT file version comment
+    next(f)
+    # Skip GCT file shape line
+    next(f)
+
+    r = csv.DictReader(f, delimiter="\t")
+
+    # Depmap added some strange headers and changed their sample ID codes,
+    # so extract the part we need from the column headers and build a mapping
+    # from sample ID (Broad ID) to column header.
+    column_to_sample = {}
+    rx = re.compile("^.* \((.*)\)$")
+    for field in r.fieldnames:
+        m = rx.search(field)
+        if m:
+            sample_code = m.group(1)
+            column_to_sample[field] = sample_code
+        
+    # Load sample metadata.
+    for row in csv.DictReader(open("data/sample_info.csv")):
+        sample_id = row["Broad_ID"]
+        b = vertex.Biosample(sample_id, ccle_attributes=row)
+        emitter.emit_vertex(b)
+
+    # Iterate all rows, writing out the expression for different tissue types
+    # to separate files.
+    for row in r:
+        for key, value in row.items():
+            if key == "gene":
+                continue
+
+            try:
+                sample = column_to_sample[key]
+            except KeyError:
+                continue
+
+            e = vertex.Expression(
+                gene_id=row["Name"],
+                sample_id=sample,
+                # TODO enum
+                scale="RPKM",
+                value=float(value),
+            )
+            emitter.emit_vertex(e)
+
+
+parser = cli.default_argument_parser()
+parser.add_argument("--emitter", type=str, default="json")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    e = emitter.get_emitter(args.emitter, prefix="ccle")
+    transform(e)
+    e.close()


### PR DESCRIPTION
I already wrote a script to split CCLE and GTEx expression into separate matrices per-tissue type for another project. I wanted to see how easily I could turn that into a BMEG ETL script.

It was fairly easy and even simplified the script slightly. Unfortunately, it is extremely slow because BMEG ETL requires one line per expression value. The overhead of serialization is huge. Originally my script ran quickly (< 1 minute) and lightly, and the output is < 1GB. Now the BMEG version runs for > 5-10 minutes, writes out many gigabytes, and heats up my laptop's fan.

Anyway, I'm also including a demo of a possibly CLI argument to switch emitters, e.g. `python mytransform.py --emitter debug`