### PR TITLE
transform: outputs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ eggs/
 *.Vertex.json
 *.Edge.json
 cache.sqlite
+
+/source
+.pytest_cache/
+/outputs

--- a/src/bmeg/emitter.py
+++ b/src/bmeg/emitter.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from bmeg.edge import Edge
 from bmeg.gid import GID
-from bmeg.utils import enforce_types
+from bmeg.utils import enforce_types, ensure_directory
 from bmeg.vertex import Vertex
 
 
@@ -146,6 +146,8 @@ class FileHandler:
     """
     def __init__(self, prefix, extension, mode="w"):
         self.prefix = prefix
+        ensure_directory("outputs", self.prefix)
+        self.outdir = os.path.join("outputs", self.prefix)
         self.extension = extension
         self.mode = mode
         self.handles = {}
@@ -162,6 +164,7 @@ class FileHandler:
             suffix = "Unknown"
 
         fname = "%s.%s.%s.%s" % (self.prefix, label, suffix, self.extension)
+        fname = os.path.join(self.outdir, fname)
 
         if fname in self.handles:
             return self.handles[fname]

--- a/src/bmeg/requests.py
+++ b/src/bmeg/requests.py
@@ -1,16 +1,22 @@
+import os
+
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 import requests_cache
 
+from bmeg.utils import ensure_directory
 
-def Client(retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504),
-           session=None):
+
+def Client(prefix, cache_name="requests_cache", retries=3, backoff_factor=0.3,
+           status_forcelist=(500, 502, 504), session=None):
     """
     Client provides a requests session that is configured with automatic
     retries, caching, and more.
     """
+    ensure_directory("outputs", prefix)
+    cache_path = os.path.join("outputs", prefix, cache_name)
     # TODO include rate limiting.
-    session = session or requests_cache.CachedSession()
+    session = session or requests_cache.CachedSession(cache_path)
     retry = Retry(
         total=retries,
         read=retries,

--- a/src/bmeg/utils.py
+++ b/src/bmeg/utils.py
@@ -1,8 +1,19 @@
+import os
 import inspect
 import typing
 
 from contextlib import suppress
 from functools import wraps
+
+
+def ensure_directory(*args):
+    path = os.path.join(*args)
+    if os.path.isfile(path):
+        raise Exception(
+            "Emitter output directory %s is a regular file", path)
+
+    if not os.path.exists(path):
+        os.makedirs(path)
 
 
 def enforce_types(callable):

--- a/transform/gdc/gdcutils.py
+++ b/transform/gdc/gdcutils.py
@@ -1,7 +1,7 @@
 from bmeg.requests import Client
 
 URL_BASE = "https://api.gdc.cancer.gov/"
-client = Client()
+client = Client("gdc")
 
 
 def query_gdc(endpoint, params):


### PR DESCRIPTION
This starts the idea of an "outputs" directory where all the outputs should be written.  For example, after running `transform/gdc`, the outputs directory looks like:

```
tree outputs/
outputs/
└── gdc
    ├── gdc.Aliquot.Vertex.json
    ├── gdc.AliquotFor.Edge.json
    ├── gdc.Biosample.Vertex.json
    ├── gdc.BiosampleFor.Edge.json
    ├── gdc.InProject.Edge.json
    ├── gdc.Individual.Vertex.json
    ├── gdc.Project.Vertex.json
    └── requests_cache.sqlite

1 directory, 8 files
```

I like the guideline we discussed today, that the source directory should mirror the transform directory. The same should apply to other directories, such as outputs.