### PR TITLE
mongoimport and example e2e tests

### DIFF
--- a/scripts/load_database.sh
+++ b/scripts/load_database.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+graph="bmeg-test"
+arachne drop $graph
+arachne create $graph
+
+gofast="--numInsertionWorkers 8 --writeConcern 0 --bypassDocumentValidation"
+
+for f in $(ls -1 outputs/*/*.Vertex.json); do
+  mongoimport -d arachnedb -c ${graph}_vertices --type json --file $f $gofast
+done
+
+for f in $(ls -1 outputs/*/*.Edge.json); do
+  mongoimport -d arachnedb -c ${graph}_edges --type json --file $f $gofast
+done

--- a/src/bmeg/emitter.py
+++ b/src/bmeg/emitter.py
@@ -114,6 +114,7 @@ class BaseEmitter:
     @enforce_types
     def emit_edge(self, obj: Edge, from_gid: GID, to_gid: GID):
         dumped = {
+            "_id": obj.make_gid(from_gid, to_gid),
             "gid": obj.make_gid(from_gid, to_gid),
             "label": obj.label(),
             "from": from_gid,
@@ -127,6 +128,7 @@ class BaseEmitter:
     @enforce_types
     def emit_vertex(self, obj: Vertex):
         dumped = {
+            "_id": obj.gid(),
             "gid": obj.gid(),
             "label": obj.label(),
             "data": self._get_data(obj)

--- a/tests/gdc/tests.py
+++ b/tests/gdc/tests.py
@@ -5,7 +5,11 @@ v = Connection("localhost:8201").graph("bmeg-test").query().V()
 
 
 def test_project():
-    res = v.where(eq("_label", "Project")).where(eq("project_id", "TCGA-BRCA")).execute()
+    q = (v.
+         where(eq("_label", "Project")).
+         where(eq("project_id", "TCGA-BRCA")))
+
+    res = q.execute()
     assert len(res) == 1
     proj = res[0]
     assert proj.gid == "Project:TCGA-BRCA"
@@ -15,11 +19,10 @@ def test_project():
 
 def test_project_biosamples():
     q = (v.
-        where(eq("_label", "Project")).
-        where(eq("project_id", "TCGA-BRCA")).
-        in_("InProject").
-        in_("BiosampleFor")
-    )
+         where(eq("_label", "Project")).
+         where(eq("project_id", "TCGA-BRCA")).
+         in_("InProject").
+         in_("BiosampleFor"))
 
     res = q.execute()
     assert len(res) > 0
@@ -28,18 +31,19 @@ def test_project_biosamples():
 
 
 def test_biosample_gid():
-    res = v.where(eq("_gid", "Biosample:2ba23626-b0f4-449b-9e4f-a4163c1cf474")).execute()
+    q = (v.
+         where(eq("_gid", "Biosample:2ba23626-b0f4-449b-9e4f-a4163c1cf474")))
+    res = q.execute()
     assert len(res) == 1
 
 
 def test_project_aliquots():
     q = (v.
-        where(eq("_label", "Project")).
-        where(eq("project_id", "TCGA-BRCA")).
-        in_("InProject").
-        in_("BiosampleFor").
-        in_("AliquotFor")
-    )
+         where(eq("_label", "Project")).
+         where(eq("project_id", "TCGA-BRCA")).
+         in_("InProject").
+         in_("BiosampleFor").
+         in_("AliquotFor"))
 
     res = q.execute()
     assert len(res) > 0

--- a/tests/gdc/tests.py
+++ b/tests/gdc/tests.py
@@ -1,0 +1,52 @@
+from aql import Connection, eq
+
+
+v = Connection("localhost:8201").graph("bmeg-test").query().V()
+
+
+def test_project():
+    res = v.where(eq("_label", "Project")).where(eq("project_id", "TCGA-BRCA")).execute()
+    assert len(res) == 1
+    proj = res[0]
+    assert proj.gid == "Project:TCGA-BRCA"
+    assert proj.label == "Project"
+    assert proj.data.project_id == "TCGA-BRCA"
+
+
+def test_project_biosamples():
+    q = (v.
+        where(eq("_label", "Project")).
+        where(eq("project_id", "TCGA-BRCA")).
+        in_("InProject").
+        in_("BiosampleFor")
+    )
+
+    res = q.execute()
+    assert len(res) > 0
+    first = res[0]
+    print(first)
+
+
+def test_biosample_gid():
+    res = v.where(eq("_gid", "Biosample:2ba23626-b0f4-449b-9e4f-a4163c1cf474")).execute()
+    assert len(res) == 1
+
+
+def test_project_aliquots():
+    q = (v.
+        where(eq("_label", "Project")).
+        where(eq("project_id", "TCGA-BRCA")).
+        in_("InProject").
+        in_("BiosampleFor").
+        in_("AliquotFor")
+    )
+
+    res = q.execute()
+    assert len(res) > 0
+    first = res[0]
+    print(first)
+
+
+def test_aliquot_gid():
+    res = v.where(eq("_gid", "Aliquot:TCGA-AR-A0U1-01A-11W-A12T-09")).execute()
+    assert len(res) == 1


### PR DESCRIPTION
This has #157 mixed in.

This includes a script for loading the ETL outputs into mongo using `mongoimport`. Seems like Arachne requires something about the `_id` field, so I'm adding that field to the emitter so that direct load to mongo works well with arachne.

This also starts a pattern for end-to-end (e2e) tests. As with other directories, E2E test should try to mirror the transform directory tree, where appropriate.