### PR TITLE
Flake8 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+
+[flake8]
+ignore = E501, E704
+exclude = 
+  .git
+  venv
+  __pycache__
+  source
+  outputs

--- a/extract/gdc/gdc-bulk-download.py
+++ b/extract/gdc/gdc-bulk-download.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     def chunks(l, n):
         for i in range(0, len(l), n):
-            yield l[i:i+n]
+            yield l[i:i + n]
 
     headers = {'Content-type': 'application/json'}
     keychunks = chunks(list(id_map.keys()), 100)

--- a/transform/go/go_gaf2schema.py
+++ b/transform/go/go_gaf2schema.py
@@ -51,9 +51,11 @@ if __name__ == "__main__":
 
                     gene_gid = Gene.make_gid(gene_id=ensembl_id)
                     go_gid = GeneOntologyTerm.make_gid(go_id=go_id)
-                    emitter.emit_edge(GeneOntologyAnnotation(
+                    emitter.emit_edge(
+                        GeneOntologyAnnotation(
                             evidence=evidence,
-                            references=references, title=title),
+                            references=references, title=title
+                        ),
                         to_gid=gene_gid,
                         from_gid=go_gid
                     )

--- a/transform/variant/allele_harvester.py
+++ b/transform/variant/allele_harvester.py
@@ -67,43 +67,43 @@ def _myvariantinfo(genome, chromosome, start, end, reference_bases,
                         return hit  # TODO - test case
                     else:
                         _log_json({
-                                        'stage': 'dbSNP_mismatch',
-                                        'genome': genome,
-                                        'chromosome': chromosome,
-                                        'start': start,
-                                        'end': end,
-                                        'reference_bases': reference_bases,
-                                        'alternate_bases': alternate_bases,
-                                        'annotations': annotations,
-                                        'url': url,
-                                        'hit': hit
-                                    })
+                            'stage': 'dbSNP_mismatch',
+                            'genome': genome,
+                            'chromosome': chromosome,
+                            'start': start,
+                            'end': end,
+                            'reference_bases': reference_bases,
+                            'alternate_bases': alternate_bases,
+                            'annotations': annotations,
+                            'url': url,
+                            'hit': hit
+                        })
     except Exception as e:  # pragma: no cover
         logging.exception(json.dumps({
-                        'stage': 'myvariantinfo_exception',
-                        'exception': str(e),
-                        'genome': genome,
-                        'chromosome': chromosome,
-                        'start': start,
-                        'end': end,
-                        'reference_bases': reference_bases,
-                        'alternate_bases': alternate_bases,
-                        'annotations': annotations,
-                        'url': url,
-                        'hit': hit
-                    }))
+            'stage': 'myvariantinfo_exception',
+            'exception': str(e),
+            'genome': genome,
+            'chromosome': chromosome,
+            'start': start,
+            'end': end,
+            'reference_bases': reference_bases,
+            'alternate_bases': alternate_bases,
+            'annotations': annotations,
+            'url': url,
+            'hit': hit
+        }))
         return None
     # default
     _log_json({
-                    'stage': 'myvariantinfo_nofind',
-                    'genome': genome,
-                    'chromosome': chromosome,
-                    'start': start,
-                    'end': end,
-                    'reference_bases': reference_bases,
-                    'alternate_bases': alternate_bases,
-                    'annotations': annotations,
-                })
+        'stage': 'myvariantinfo_nofind',
+        'genome': genome,
+        'chromosome': chromosome,
+        'start': start,
+        'end': end,
+        'reference_bases': reference_bases,
+        'alternate_bases': alternate_bases,
+        'annotations': annotations,
+    })
 
 
 def harvest(genome, chromosome, start, end, reference_bases, alternate_bases,
@@ -115,16 +115,16 @@ def harvest(genome, chromosome, start, end, reference_bases, alternate_bases,
                     alternate_bases, annotations)
     if allele.gid() in filter:
         _log_json({
-                        'stage': 'filtered',
-                        'allele_gid':  allele.gid(),
-                        'genome': genome,
-                        'chromosome': chromosome,
-                        'start': start,
-                        'end': end,
-                        'reference_bases': reference_bases,
-                        'alternate_bases': alternate_bases,
-                        'annotations': annotations,
-                    })
+            'stage': 'filtered',
+            'allele_gid': allele.gid(),
+            'genome': genome,
+            'chromosome': chromosome,
+            'start': start,
+            'end': end,
+            'reference_bases': reference_bases,
+            'alternate_bases': alternate_bases,
+            'annotations': annotations,
+        })
         return None
 
     if harvest:

--- a/transform/variant/maf_transform.py
+++ b/transform/variant/maf_transform.py
@@ -83,11 +83,12 @@ def _read_maf(mafpath, gz, skip=0, harvest=True):
 
 def _allele_call_maker(allele, line=None):
     """ create call from line """
-    keys = ['t_depth', 't_ref_count', 't_alt_count', 'n_depth',
-            'n_ref_count', 'n_alt_count', 'FILTER',
-            'Match_Norm_Seq_Allele1',	'Match_Norm_Seq_Allele2',
-            'Tumor_Seq_Allele1', 'Tumor_Seq_Allele2',
-            ]
+    keys = [
+        't_depth', 't_ref_count', 't_alt_count', 'n_depth',
+        'n_ref_count', 'n_alt_count', 'FILTER',
+        'Match_Norm_Seq_Allele1', 'Match_Norm_Seq_Allele2',
+        'Tumor_Seq_Allele1', 'Tumor_Seq_Allele2',
+    ]
     info = {}
     for k in keys:
         info[k] = get_value(line, k, None)
@@ -169,11 +170,11 @@ def _multithreading(func, lines, max_workers, harvest, filter):
     Create a thread pool and create alleles
     """
     # limit queue size == number of workers
-    # see https://stackoverflow.com/questions/48263704/threadpoolexecutor-how-to-limit-the-queue-maxsize  # noqa
+    # see https://stackoverflow.com/questions/48263704/threadpoolexecutor-how-to-limit-the-queue-maxsize
 
     for chunk in chunked(lines, max_workers):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = (executor.submit(func, line, harvest, filter) for line in chunk)  # noqa
+            futures = (executor.submit(func, line, harvest, filter) for line in chunk)
             for future in as_completed(futures):
                 yield future.result()
 

--- a/transform/variant/miss_analysis.py
+++ b/transform/variant/miss_analysis.py
@@ -38,23 +38,22 @@ for line in sys.stdin:
         ref = line['hit']['vcf']['ref']
         alt = line['hit']['vcf']['alt']
         if len(ref) > 1:
-            ref_diff = sum([{' ': 0, '-': 1,  '+': 1}[d[0]] for d in difflib.ndiff(line['reference_bases'], ref)])  # noqa
+            ref_diff = sum([{' ': 0, '-': 1, '+': 1}[d[0]] for d in difflib.ndiff(line['reference_bases'], ref)])
             if ref_diff == 1:
                 summary['ref_off_by_one'] += 1
         if len(alt) > 1:
-            alt_diff = sum([{' ': 0, '-': 1, '+': 1}[d[0]] for d in difflib.ndiff(line['alternate_bases'], alt)])  # noqa
+            alt_diff = sum([{' ': 0, '-': 1, '+': 1}[d[0]] for d in difflib.ndiff(line['alternate_bases'], alt)])
             if alt_diff == 1:
                 summary['alt_off_by_one'] += 1
 
-summary['missing_snp'] = summary['dbSNP_RS'].get('novel', 0) \
-                         + summary['dbSNP_RS'].get('.', 0)
+summary['missing_snp'] = summary['dbSNP_RS'].get('novel', 0) + summary['dbSNP_RS'].get('.', 0)
 
 report = 'misses = {}%; novel = {}%; wildcard_misses ={}%; dbSNP_mismatch ={}%'
 summary['report'] = report.format(
-    ((summary['myvariantinfo_nofind']+summary['dbSNP_mismatch']) * 100)/summary['total'],  # noqa
-    (summary['missing_snp']*100)/summary['total'],
-    ((summary['alternate_wildcard'] + summary['reference_wildcard']) * 100)/summary['total'],  # noqa
-    (summary['dbSNP_mismatch']*100)/summary['total'],
+    ((summary['myvariantinfo_nofind'] + summary['dbSNP_mismatch']) * 100) / summary['total'],
+    (summary['missing_snp'] * 100) / summary['total'],
+    ((summary['alternate_wildcard'] + summary['reference_wildcard']) * 100) / summary['total'],
+    (summary['dbSNP_mismatch'] * 100) / summary['total'],
 )
 
 del summary['Feature']

--- a/transform/variant/tests/test_maf_transform.py
+++ b/transform/variant/tests/test_maf_transform.py
@@ -63,7 +63,7 @@ def validate(maf_file, emitter_path_prefix, harvest=True, filter=[]):
     # test.Allele.Vertex.json
     error_message = 'maf_transform.convert({}, {}) should create {}' \
                     .format(maf_file, emitter_path_prefix, allele_file)
-    assert os.path.isfile(allele_file),  error_message
+    assert os.path.isfile(allele_file), error_message
     # test allele contents
     with open(allele_file, 'r', encoding='utf-8') as f:
         for line in f:
@@ -91,7 +91,7 @@ def validate(maf_file, emitter_path_prefix, harvest=True, filter=[]):
     # test.Callset.Vertex.json
     error_message = 'maf_transform.convert({}, {}) should create {}' \
                     .format(maf_file, emitter_path_prefix, callset_file)
-    assert os.path.isfile(callset_file),  error_message
+    assert os.path.isfile(callset_file), error_message
     # test allele contents
     with open(callset_file, 'r', encoding='utf-8') as f:
         for line in f:
@@ -106,7 +106,7 @@ def validate(maf_file, emitter_path_prefix, harvest=True, filter=[]):
     # test.AlleleCall.Edge.json
     error_message = 'maf_transform.convert({}, {}) should create {}' \
                     .format(maf_file, emitter_path_prefix, allelecall_file)
-    assert os.path.isfile(allelecall_file),  error_message
+    assert os.path.isfile(allelecall_file), error_message
     # test allele contents
     with open(allelecall_file, 'r', encoding='utf-8') as f:
         for line in f:


### PR DESCRIPTION
This disables the check for lines over 80 characters, which is too stringent and annoying. It's resulted in a lot of `# noqa` lines, or lines that are forced into some ugly short form.

Adding flake8 config also triggered a bunch of new errors, which were previously being missed for some reason. I fixed those.