### PR TITLE
PFam split

### DIFF
--- a/transform/pfam/download.py
+++ b/transform/pfam/download.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import os
+import tarfile
+
+import bmeg.requests
+from bmeg.util.cli import default_argument_parser
+
+
+client = bmeg.requests.Client("pfam")
+parser = default_argument_parser()
+parser.add_argument(
+    "--archive",
+    "-A",
+    action="store_true",
+    default=False,
+    help="create a gzipped TAR archive of all the output files")
+
+args = parser.parse_args()
+
+output_dir = "outputs/pfam"
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+
+if not os.path.exists("outputs/pfam/id_list.txt"):
+    raise Exception("missing ID list. Run transform/pfam/list.py")
+
+ids = open("outputs/pfam/id_list.txt").read().splitlines()
+
+if args.archive:
+    tar = tarfile.open(os.path.join(output_dir, "pfam.tar.gz"), "w:gz")
+
+for i in ids:
+    handle = client.get("http://pfam.xfam.org/family?output=xml&acc=%s" % i)
+    txt = handle.text
+    f = os.path.join(output_dir, "%s.xml" % (i))
+    with open(f, "w") as handle:
+        handle.write(txt)
+
+    if args.archive:
+        tar.add(f, arcname=os.path.basename(f))
+
+if args.archive:
+    tar.close()

--- a/transform/pfam/list.py
+++ b/transform/pfam/list.py
@@ -1,0 +1,10 @@
+import requests
+
+with open("outputs/pfam/id_list.txt", "w") as fh:
+    handle = requests.get("http://pfam.xfam.org/families?output=text")
+    for line in handle.iter_lines():
+        line = line.decode()
+        if not line.startswith("#"):
+            row = line.split("\t")
+            if len(row[0]) > 1:
+                print(row[0], file=fh)


### PR DESCRIPTION
This splits the pfam transformer into three separate scripts, which is simpler to understand than one script with three subcommands mixed into one file.