### PR TITLE
compounds: additional aliases

### DIFF
--- a/source/drug_enricher/drug_alias.tsv
+++ b/source/drug_enricher/drug_alias.tsv
@@ -1,104 +1,825 @@
 name	alias
-06 BG	NO-FIND
-06-BG	NO-FIND
+06 BG	06-Benzylguanine
+06-BG	06-Benzylguanine
+06-BG (NABTT 0803)	06-Benzylguanine
+06BG	06-Benzylguanine
+06GB	06-Benzylguanine
+17-AAG	Demethoxygeldanamycin
+17-AAG	Tanespimycin
+17AAG	Demethoxygeldanamycin
+2-[1-hexyloxyethyl]-2-devinyl pyropheophorbide-alpha (HPPH or Photochlor)	Photochlor
+2B3-101	Doxorubicin
+5 FU	Fluorouracil
 5 Flourouracil	5 fluorouracil
 5 Fluoruoracil	5-fluorouracil
-5- FU	NO-FIND
+5 fluorouracil	Fluorouracil
+5 fluorouracil+leucovorin	Fluorouracil+Leucovorin
+5 fluorouracilum	Fluorouracil
+5 fluorouracilum+leucovorin	Fluorouracil+Leucovorin
+5- FU	Fluorouracil
+5-FLUOROURACIL	Fluorouracil
+5-FU	Fluorouracil
+5-FU + LEULOV	Fluorouracil+Leucovorin
+5-FU+ etoposidium	Fluorouracil+Etoposide
 5-Flourouracil	5-fluorouracil
+5-Flourouracil	Fluorouracil
+5-Fluorouracil	Fluorouracil
+5-Fluorouracil + leucovorin	Fluorouracil+Leucovorin
+5-Fluorouracil?	Fluorouracil
 5-Fluoruoracil	5-fluorouracil
+5-Fluoruoracil	Fluorouracil
+5-fluorouracil	Fluorouracil
+5-fluorouracilum	Fluorouracil
+5-flurouracil	Fluorouracil
+5-fu	Fluorouracil
 58500	NO-FIND
+5F4 LEUCOVORIN	Leucovorin
+5F4 Leucovorin	Fluorouracil+Leucovorin
+5FU	Fluorouracil
 5fluorouracil	5 fluorouracil
+5fluorouracil+leucovorin	Fluorouracil+Leucovorin
+5fluorouracil+oxaciplatina+l-folinian discido	Oxaliplatin+Leucovorin+Fluorouracil
+6 THIGUANINE	Tioguanine
+6 THIOGUANINE	Tioguanine
+6 Thiguanine	'Tioguanine'
 6 Thiguanine	6-thioguanine
+6-MERCAPTOPURINE	Tioguanine
+81C6	81C6
+9 AMINOCAMPTOTHECIN	9-AMINOCAMPTOTHECIN
+9 Aminocamptothecin	Aminocamptothecin
+9 IMMUNOAMINO CAMPTNETECIN	9-AMINOCAMPTOTHECIN
+90Y-HU3S193	90Y-HU3S193
+90Y-HU3S193	Hu3S193
 97212	NO-FIND
-AE 788	NO-FIND
+A202171 Protocol	NOS
+A443654	A443654
+A769662	A769662
+A770041	A770041
+ABRAXANE	Paclitaxel
+ABT-888	Veliparib
+ABT-888 PARP INHIBITOR	Veliparib
+ABT-888 and temozolomide	Veliparib+Temozolomide
+ABT263	Navitoclax
+ABT888	Veliparib
+ABTC 0603 HYDROXYCHLOROQUINE	Hydroxychloroquine
+AC	Cyclophosphamide+Doxorubicin
+ACCTUANE	Isotretinoin
+ACCUTANE	Isotretinoin
+ADRIAMYCIN	Doxorubicin
+ADRIMYCIN	Doxorubicin
+AE 788	AE788
+AE-37	AE37
+AFATINIB	AFATINIB
+AFINITOR	Everolimus
+AICAR	AICAR
 AKT inhibitor VIII (1)	akt inhibitor
+ALBUMIN-BOUND PACLITAXEL	Paclitaxel
+ALIMTA	Pemetrexed
+ALMITA	Pemetrexed
+ALPHA INTERFERON	Alpha interferon
+AMG 102	Rilotumumab
+AMG 706	Motesanib
+AMG 706	motesanib
+AMG706	motesanib
+AMGEN 706	motesanib
+AMINOPTERIN	AMINOPTERIN
+AMITOSTIN	Amifostine
+AMITOSTINE	Amifostine
+ANASTROZOLE	Anastrozole
+ANASTROZOLE (ARIMIDEX)	Anastrozole
+ANGIOCEPT	Angiocept
+ANTI NEOPASTONS	Anti Neoplastons
+AP-23573 (ARIAD)	Ridaforolimus
+AP24534	ponatinib
+ARIAD AP23573	Deforolimus
+ARIMIDEX	Anastrozole
+ARIMIDEX (ANASTROZOLE)	Anastrozole
+ARMIDEX	Anastrozole
+AROMASIN	Exemestane
+AROMASIN (EXEMESTANE)	Exemestane
+ARSENIC TNOXIDE	ARSENIC TRIOXIDE
+ARSENIC TRIOXIDE	ARSENIC TRIOXIDE
+AS601245	AS601245
+AT 101	AT-101
+AT-101	AT-101
 ATTAC	NO-FIND
+AUY922	AUY922
+AVASTIN	Bevacizumab
+AVASTIN (BEVACIZUMAB)	Bevacizumab
+AVASTIN/BEVACIZUMAB/PLACEBO	Bevacizumab
+AXITINIB	Axitinib
+AZ628	Sorafenib tosylate
+AZD	AZD
+AZD 2281	Olaparib
+AZD0530	saracatinib
+AZD2281	Olaparib
+AZD6244	Selumetinib
+AZD6482	AZD6482
+AZD7762	AZD7762
+AZD8055	AZD8055
+Abagovomab or Placebo	Abagovomab
+Abagovomab vs Placebo	Abagovomab
+Abagovomag	abagovomab
+Abagovomag vs Placebo	Abagovomab
+Abiraterone	Abiraterone
+Abraxane	Paclitaxel
 Acctuane	accutane
+Actinomycin-D	Dactinomycin
+Adriamycin	Doxorubicin
+Adriamycin (doxorubicin)	Doxorubicin
+Adriamycin, cytoxan, avastin	Doxorubicin+Cyclophosphamide+Bevacizumab
+Adriamycin/Cytoxan	Doxorubicin+Cyclophosphamide
+Adriamyicin	Doxorubicin
+Adrimycin	Doxorubicin
 Adrimycin	adriamycin
+Afatinib	Afatinib
+Afinitor	Everolimus
+Aflibercept	Aflibercept
+Aflibercept/ Placebo Study	Aflibercept
 Agent	NO-FIND
-Almita	NO-FIND
-Amgen	NO-FIND
+Albumin-Bound Paclitaxel	Paclitaxel
+Alferon	Alferon
+Alimta	Pemetrexed
+Alkeran	Melphalan
+Almita	Pemetrexed
+Almita	alimta
+Aloxi	Palonosetron
+Alpha Interferon	Alferon
+Altima	Pemetrexed
+Alvesin	Alvesin
+Amatuximab (MORab-009)	Amatuximab
+Amgen 706	Motesanib
 Amgen 706	amg 706 amgen
+Amifostine	Amifostine
+Aminopterin	Aminopterin
+Amitostin	Amifostine
+Amitostine	Amifostine
+Anastrazole	Anastrozole
+Anastrozole	Anastrozole
+Angiocal	Angiocal
+Anti necplatens	Antineoplastons
+Arimidex	Anastrozole
+Arimidex (Anastrozole)	Anastrozole
+Armidex	Anastrozole
 Armidex	arimidex
-BA4 43	NO-FIND
-BS1 201	NO-FIND
-BS1-201	NO-FIND
+Armour Thyroid	Desiccated thyroid
+Aromasin	Exemestane
+Aromasin (Exemestane)	Exemestane
+Avastin	Bevacizumab
+Avastin (Bevacizumab)	Bevacizumab
+Avastin/bevacizumab/placebo	Bevacizumab
+Axitinib	Axitinib
+Axitnib	Axitinib
+B12	Cyanocobalamin
+BA4 43	Sorafenib
+BA4 43 9006	Sorafenib
+BAY-439006	Sorafenib
+BAY613606	BAY613606
+BCG	BCG
+BCG, Intravesicular	BCG
+BCNU	Carmustine
+BCNU (CARMUSTINE)	Carmustine
+BCNU (Carmustine)	Carmustine
+BCNU (carmustine)	Carmustine
+BEVACIZUMAB	Bevacizumab
+BEVACIZUMAB (AVASTIN)/PLACEBO PROVIDED BY STUDY	Bevacizumab
+BEVACIZUMAB AVASTIN	Bevacizumab
+BEVACIZUmab	Bevacizumab
+BEVACIZumab	Bevacizumab
+BEVACOZIMAB	Bevacizumab
+BEXAROTENE	Bexarotene
+BI2536	BI2536
+BIBW 2992	Afatinib
+BIBW2992	Afatinib
+BICALUTAMIDE	Bicalutamide
+BID1870	BID1870
+BIRB0796	BIRB0796
+BISPHOPHONATE (ZOLEDRONIC ACID)	zoledronate
+BLEOMYCIN	Bleomycin
+BMS509744	BMS509744
+BMS536924	BMS536924
+BMS754807	BMS754807
+BORTEZOMIB	Bortezomib
+BOSUTINIB	Bosutinib
+BRAF inhibitor	Vemurafenib
+BROMO DEOXYURIDINE	Bromodeoxyuridine
+BRYOSTATIN1	Bryostatin 1
+BS1 201	Iniparib
+BS1-201	Iniparib
+BS1-201	Iniparib
+BSI-201	Iniparib
+BX795	BX795
 BX796	NO-FIND
+Bacillus Calmette-Guerin (BCG)	BCG
+Bay-439006	Sorafenib
+Belinostat	Belinostat
+Benzylguanine	O6-Benzylguanine
 Bevacizamab	bevacizumab
+Bevacizamab/Placebo	Bevacizumab
+Bevacizumab	Bevacizumab
+Bevacizumab or Placebo	Bevacizumab
+Bevacizumab or placebo	Bevacizumab
+Bevacizumab vs Placebo	Bevacizumab
+Bevacizumiab/ versus Placebo	Bevacizumab
+Bevacozimab	bevacizumab
 Bevcizumab	bevacizumab
+Bicalutamid	Bicalutamide
+Bicalutamide	Bicalutamide
+Bleomycin	Bleomycin
+Bortezomib	Bortezomib
+Brivanib	Brivanib
+Bromo deoxyuridine	Bromodeoxyuridine
+C1 FOLFIRI/Zaltrap	Leucovorin+Fluorouracil+Irinotecan+Aflibercept
+CAI NABIT 9712	CAI NABIT 9712
+CALCIUM FOLIATUM	Calcium Folate
+CALCIUM FOLIATUM 420MG	Calcium Folate
+CAMPTOSAR	Irinotecan
+CAMPTOTHECIN	Camptothecin
+CAPECETABINE	Capecitabine
+CAPECITABIN	Capecitabine
+CAPECITABINE	Capecitabine
+CARBO	Carboplatin
+CARBOBPLATIN	Carboplatin
+CARBOPALTIN	Carboplatin
+CARBOPLASTIN	Carboplatin
+CARBOPLATIN	Carboplatin
+CARBOPLATIN #1	Carboplatin
+CARBOPLATIN & PACLITAXEL	CARBOPLATIN & PACLITAXEL
+CARBOPLATIN 6TH	Carboplatin
+CARBOPLATINUM	Carboplatin
+CARBOXY AMIDO TRIAZOLE	Carboxyamidotriazole
+CARBOplatin	Carboplatin
+CARBPLATIN	Carboplatin
+CARMUSTIN	Carmustine
+CARMUSTINE	Carmustine
+CARMUSTINE (BCNU)	Carmustine
+CARMUSTINE BCNU	Carmustine
+CASODEX	Bicalutamide
+CATUMAXUMAB	Catumaxomab
+CAV Trial	Cyclophosphamide+Dactinomycin+Vincristine
+CBP501	CBP501
+CCDP	Cisplatin
+CCNG	CCNG
+CCNU	CCNU
+CCNU	Lomustine
+CCNu	Lomustine
+CDDP	Cisplatin
+CDR0000654697	NOS
+CELBREX	Celecoxib
+CELEBREX	Celecoxib
+CEP 11981	CEP -11981
+CEP 11981	CEP11981
+CEP701	Lestaurtinib
+CEPECITABINE	CAPECITABINE
+CETUXIMAB	Cetuximab
+CETUXIMEB	Cetuximab
+CETUXimab	Cetuximab
+CGP082996	CGP082996
+CGP60474	CGP60474
+CH81C6	CH81C6
+CHIR99021	CHIR99021
+CHLORAMBUCIL	Chlorambucil
+CHLOROQUINE	Chloroquine
+CHOP	Cyclophosphamide+Doxorubicin+Vincristine+Prednisone
+CI 980	CI-980
+CI-980	CI-980
+CI1040	CI-1040
+CI980	CI-980
+CILENAITIDE	Cilengitide
+CILENGITIDE	Cilengitide
+CIPLASTIN	Cisplatin
+CIS RETINOIC ACID	Cis Retinoic Acid
+CIS Retinoic Acid	Isotretinoin
+CIS-RETINOIC ACID	Cis Retinoic Acid
+CISPLASTIN	Cisplatin
+CISPLATAIN	Cisplatin
+CISPLATIN	Cisplatin
+CISPLATIN #2-7	Cisplatin
+CISPLATIN/GEMZAR	CISPLATIN/GEMZAR
+CISPLATINUM	Cisplatin
+CISPLATINUM 120MG	Cisplatin
+CISTPLATIN	Cisplatin
+CISplatinum	Cisplatin
+CLODRONATE	Clodronic acid
+CLODRONIC ACID	Clodronic acid
+CLORETAZINE	Cloretazine
+CMK	KIN001-128
+COPOLANG CAPS	Cyclophosphamide+Polysaccharide-K
+CPT 11	Irinotecan
+CPT-11	Irinotecan
+CPT11	Irinotecan
 CPT11	cpt 11
+CRA	Isotretinoin
+CT2103 TAXANE ANALOG	CT-2103
+CT2103 Taxane Analog	Paclitaxel
+CVAD	Cyclophosphamide+Vincristine+Doxorubicin+Dexamethasone
+CYC-116/Cyclocel	Cyclophosphamide+CYC116
+CYCLOPAMINE	Cyclopamine
+CYCLOPHASPHAMIDE	Cyclophosphamide
+CYCLOPHOSPAMIDE	Cyclophosphamide
+CYCLOPHOSPHAMID+METOTREKSAT+  FLUOROURACIL	Cyclophosphamide+Methotrexate+Fluorouracil
+CYCLOPHOSPHAMIDE	Cyclophosphamide
+CYOTXAN	Cyclophosphamide
+CYTARABINE	Cytarabine
+CYTOXAN	Cyclophosphamide
+CYTOXAN AND TAXOTERE	Cyclophosphamide+Docetaxel
+CYTOXEN	Cyclophosphamide
+CYTOXIN	Cyclophosphamide
+Cabazitaxel	Cabazitaxel
+Calcium Foliatum	Leucovorin
+Calcium Foliatum, fluorouracilum, oxaliplatinum, dexamethassone	Leucovorin+Oxaliplatin+Fluorouracil+Dexamethasone
+Camptosar	Irinotecan
+Cancer Vax	Polyvalent Melanoma Vaccine
+Capecetabine	Capecitabine
 Capecetabine	capecitabine
+Capecitabin	Capecitabine
+Capecitabine	Capecitabine
+Capecitabine -xeloda	Capecitabine
+Capecytabinum	Capecitabine
+Carbo	Carboplatin
+CarboPlatinum	Carboplatin
+Carbobplatin	Carboplatin
+Carboplatin	Carboplatin
+Carboplatin #1	Carboplatin
+Carboplatin & Paclitaxel	Carboplatin
+Carboplatin 5 AUC	Carboplatin
+Carboplatin 6th	Carboplatin
+Carboplatin Paclitaxel	Carboplatin+Paclitaxel
+Carboplatin and Paclitaxel	Carboplatin+Paclitaxel
+Carboplatin, Taxol	Carboplatin+Paclitaxel
+Carboplatin/Paclitaxel	Carboplatin+Paclitaxel
+Carboplatin/Paclitaxel/Bevacizumab	Carboplatin+Paclitaxel+Bevacizumab
+Carboplatin_Paclitaxel	Carboplatin+Paclitaxel
+Carboplatinum	Carboplatin
+Carbplatin	Carboplatin
 Carbplatin	carboplatin
+Carmustin	Carmustine
+Carmustine	Carmustine
+Carmustine (BCNU)	Carmustine
+Carmustine BCNU	Carmustine
+Casodex	Bicalutamide
+Catumaxumab	Catumaxomab
 Catumaxumab	catumaxomab
+Cedicanib	Cediranib
+Cediranib	Cediranib
+Cediranib Placebo	Cediranib
+CeeNU	Lomustine
 Celbrex	celebrex
+Celebrex	Celecoxib
+Cepecitabine	Capecitabine
 Cepecitabine	capecitabine
+Cetuximab	Cetuximab
+Cetuximab Study drug	Cetuximab
 Chemo	NO-FIND
 Chemo Multi	NO-FIND
 Chemo NOS	NO-FIND
+Chemo, Multi-Agent, NOS	NOS
 Chemo, NOS	NO-FIND
+Chemo, NOS	NOS
+Chlorambucil	Chlorambucil
+Ciclosporin	Cyclosporine
+Cilenaitide	Cilengitide
+Cilengitide	Cilengitide
+Cilengtide	Cilengitide
+Ciplastin	Cisplatin
 Ciplastin	cisplatin
+Cis Retinoic Acid	Isotretinoin
 Cisplatain	cisplatin
+Cisplatin	Cisplatin
+Cisplatin #2-7	Cisplatin
+Cisplatin, pemetrexed	Cisplatin+Pemetrexed
+Cisplatin-xrt	Cisplatin
+Cisplatin/Etoposide	Cisplatin+Etoposide
+Cisplatin/Gemzar	Cisplatin+Gemcitabine
+Cisplatinum	Cisplatin
+Cisplatnin	Cisplatin
+Clinical Trial	NOS
+Clinical Trial-Study Agent	NOS
+Clinical trial	NOS
+Clodronate	Clodronate
+Cloretazine	Laromustine
+Copolang	Cyclophosphamide+Polysaccharide-K
+Cyclophasphamide	Cyclophosphamide
 Cyclophasphamide	cyclophosphamide
+Cyclophospamide	Cyclophosphamide
 Cyclophospamide	cyclophosphamide
+Cyclophosphamide	Cyclophosphamide
+Cyclophosphane	Cyclophosphamide
+Cyotxan	Cyclophosphamide
 Cyotxan	cytoxan
+Cytomel	Liothyronine
+Cytoxan	Cyclophosphamide
+Cytoxan and Taxotere	Cyclophosphamide+Docetaxel
+Cytoxan, vincristine and dacarbazine	Cyclophosphamide+Vincristine+Dacarbazine
+Cytoxen	Cyclophosphamide
 Cytoxen	cytoxan
+Cytoxin	Cyclophosphamide
+DACLIZUMAB	Daclizumab
+DASATINIB	Dasatinib
+DECODRON	Dexamethasone
+DEXAETHASONE	Dexamethasone
+DEXAMETHASOME	Dexamethasone
+DEXAMETHASONE	Dexamethasone
+DEXAMETHASSONE	Dexamethasone
+DEXAMETHAZONE	Dexamethasone
+DEXAMETHSONE	Dexamethasone
+DEXAMTHASONE	Dexamethasone
+DEXMETHASONE	Dexamethasone
+DMOG	Dimethyloxaloylglycine
+DOCETAXEL	Docetaxel
+DOCETOXEL/TAXOTERE	Docetaxel
+DOXETAXEL	Docetaxel
+DOXIL	Doxorubicin
+DOXORIBICIN	Doxorubicin
+DOXORUBICIN	Doxorubicin
+DOXORUBICIN HCI LIIPOSOMAL	Doxorubicin
+DOXORUBICIN HCI LIPSOME	Doxorubicin
+DOXORUBICIN HCL	Doxorubicin
+DOXORUBICIN HCL LIPOSOMAL	Doxorubicin
+DOXORUBICIN HCL LIPOSOMAL -DOXIL	Doxorubicin
+DOXORUBICIN+CYCLOPHOSPHAMID	Cyclophosphamide+Doxorubicin
+DOXORUBICINE CYCLOPHOSPHAMIDE (ENDOXAN ADVIBLASTIN)	Cyclophosphamide+Doxorubicin
+DOXORUBINCIN	Doxorubicin
+DOXORUBINCIN HCL	Doxorubicin
+DS-8273a	DS-8273a
+DTIC	Dacarbazine
+DTIC, Dacarbazine	Dacarbazine
+Dabrafenib	Dabrafenib
+Dacabarzine	Dacarbazine
+Dacarbazine	Dacarbazine
+Dacarbazine (DTIC)	Dacarbazine
+Dasatinib	Dasatinib
+Decodron	Dexamethasone
 Decodron	decadron
+Denosumab	Denosumab
 Dexaethasone	dexamethasone
 Dexamethasome	dexamethasone
+Dexamethasone	Dexamethasone
+Dexamethasone phosphate	Dexamethasone
 Dexamethsone	dexamethasone
 Dexamthasone	dexamethasone
 Dexmethasone	dexamethasone
-Docetaxelum	NO-FIND
+Didox	Didox
+Diphencyprone	Diphencyprone
+Docetaxel	Docetaxel
+Docetaxel +/- Zactima	Docetaxel+Vandetanib
+Docetaxelum	Docetaxel
+Docetoxel/Taxotere	Docetaxel
 Docorubicin	doxorubicin
+Doxetaxel	Docetaxel
 Doxetaxel	docetaxel
+Doxetaxol	Docetaxel
 Doxetaxol	docetaxel
+Doxifluridin	Doxifluridine
+Doxifluridine	Doxifluridine
+Doxil	Doxorubicin
+Doxil & Carboplatin	Doxorubicin+Carboplatin
+Doxirubicin	Doxorubicin
+Doxobubicin	Doxorubicin
 Doxorubican	doxorubicin
+Doxorubicin	Doxorubicin
+Doxorubicin HCI Liiposomal	Doxorubicin
+Doxorubicin HCI Lipsome	Doxorubicin
+Doxorubicin HCL	Doxorubicin
+Doxorubicin HCL Liposomal	Doxorubicin
+Doxorubicin HCL Liposomal -Doxil	Doxorubicin
+Doxorubicin HCl Liposomal	Doxorubicin
+Doxorubicin Liposome	Doxorubicin
+Doxorubicinum	Doxorubicin
 Doxorubincin	doxorubicin
+Doxorubincin HCL	Doxorubicin
+E-75	Nelipepimut-S
+ELESCLOMOL	Elesclomol
+EMBELIN	embelin
+EMD	NOS
+EMD 121974	Cilengitide
+ENZASTAURIN	Enzastaurin
+EPIRUBICIN	Epirubicin
+EPIRUBICINUM 70MG	Epirubicin
+EPOCH	Etoposide+Prednisone+Vincristine+Doxorubicin
+EPOTHILONEB	epothilone
+ERBITUX	Cetuximab
+ERLOTINIB	Erlotonib
+ERLOTONIB	Erlotonib
+ESTRAMUSTINE	Estramustine
+ET-743	Trabectedin
+ETC Posidum	Etoposide
+ETOPOSDIE	Etoposide
+ETOPOSIDE	Etoposide
+ETOPOSIDE (VP16)	Etoposide
+ETOPSIDE	Etoposide
+EVEROLIMUS	Everolimus
+EVERolimus	Everolimus
+EXEMESTANE	Exemestane
+EXEMESTANE (AROMASIN)	Exemestane
+EZN-2968	EZN-2968
+Eligard	Leuprolide
+Eloxatin	Oxaliplatin
+Eloxatin(oxaliplatin)	Oxaliplatin
+Enoticumab	REGN421
+Epirubicin	Epirubicin
+Epirubicoin	Epirubicin
+Erbitux	Cetuximab
+Eribulin	Eribulin
+Erlotinib	Erlotinib
+Erlotonib	Erlotinib
 Erlotonib	erlotinib
+Erythropoietin	Epoetin
+Etoposid	Etoposide
+Etoposide	Etoposide
+Etoposide (VP16)	Etoposide
+Etoposide phosphate	Etoposide
+Etopside	Etoposide
+Everolimus	Everolimus
+Everolimus, Gemcitabine, and Cisplatin	Everolimus+Gemcitabine+Cisplatin
+Exemestane	Exemestane
+FARESTON	Toremifene
+FASLODEX	Fulvestrant
+FEMARA	Letrozole
+FEMARA (LETROZOLE)	Letrozole
+FENRETINIDE	Fenretinide
+FH535	FH535
+FILGRASTIM (G-CSF)	Filgrastim
+FLC	NOS
+FLOURORACIL	Fluorouracil
+FLOUROURACIL	Fluorouracil
 FLOUROURACIL	fluorouracil
+FLOXURIDINE	Floxuridine
+FLUOROURACIL	Fluorouracil
+FLUOROURACILUM	Fluorouracil
+FLUOROURACILUM 2100MG	Fluorouracil
+FOLFIRI	Leucovorin+Fluorouracil+Irinotecan
+FOLFIRI/Avastin	Leucovorin+Fluorouracil+Irinotecan+Bevacizumab
+FOLFOX	Leucovorin+Fluorouracil+Oxaliplatin
+FOLINIC ACID	Leucovorin
+FOTEMUSTINA	Fotemustine
+FOTEMUSTINE	Fotemustine
+FT	Ftorafur
+FTI277	FTI-277
+FU7	NOS
+FUDR (FLOXURIDINE)	Floxuridine
+FUDR (Floxuridine)	Floxuridine
+FULUESTRANT	Fulvestrant
+FULVESTRANT	Fulvestrant
+FULVESTRANT (FASLODEX)	Fulvestrant
+Fareston	Toremifene
+Faslodex	Fulvestrant
+Femara	Letrozole
+Femara (Letrozole)	Letrozole
+Filgrastim (G-CSF)	Filgrastim
+Firmagon	Degarelix
 Flourouracil	fluorouracil
+Floxuridine	Fluorouracil
+Fluorouracil	Fluorouracil
+Fluorouracil (5-FU)	Fluorouracil
+Fluorouracil IV Continuous infusion over 46 hours	Fluorouracil
+Fluorouracilum	Fluorouracil
 Fluoruoracil	fluorouracil
+Fluoruracil	Fluorouracil
+FolFox	Leucovorin+Fluorouracil+Oxaliplatin
+Folfiri	Leucovorin+Fluorouracil+Irinotecan
+Folfox	Leucovorin+Fluorouracil+Oxaliplatin
+Folinic Acid	Leucovorin
+Folinic acid	Leucovorin
+Fotemustine	Fotemustine
+Fuluestrant	Fulvestrant
 Fuluestrant	fulvestrant
-GOG 218	NO-FIND
-GOG182	NO-FIND
+Fulvestrant	Fulvestrant
+Fulvestrant (Faslodex)	Fulvestrant
+GAMINOCAMPTOTHECIN	aminocamptothecin
+GAMZAR	Gemcitabine
+GDC-0980	GDC-0980
+GDC0449	Vismodegib
+GDC0941	GDC-0941
+GEFITINIB	Gefitinib
+GEMAR	Gemcitabine
+GEMCITABIN	Gemcitabine
+GEMCITABINE	Gemcitabine
+GEMCITABINE HCI	Gemcitabine
+GEMCITABINE HCL	Gemcitabine
+GEMCITABINE/CISPLATIN	Gemcitabine+Cisplatin
+GEMCITIBANE	Gemcitabine
+GEMCITIBINE	Gemcitabine
+GEMICITABINE	Gemcitabine
+GEMICTIABINE	Gemcitabine
+GEMZAN	Gemcitabine
+GEMZAR	Gemcitabine
+GEMZAR (GEMCITABINE)	Gemcitabine
+GEMZET	Gemcitabine
+GEZMAR	Gemcitabine
+GL-ONC1	GL-ONC1
+GLEEVAC	Imatinib
+GLEEVEC	Imatinib
+GLIADEL	Carmustine implant
+GLIADEL BCNU	Carmustine implant
+GLIADEL WAFER	Carmustine implant
+GLIADEL WAFER (BCNU)	Carmustine implant
+GLIADEL WAFER CARMUSTINE	Carmustine implant
+GLIADEL WAFERS	Carmustine implant
+GLIADEL WATERS	Carmustine implant
+GLIADLE WAFER	Carmustine implant
+GM-CSF	Sargramostim
+GOG 218	GOG 218
+GOG182	GOG 182
+GOMZAR	Gemcitabine
+GOSERELIN	GOSERELIN
+GP-100	GP100
+GP100	GP100
+GSK Braf Inhibitor	Dabrafenib
+GSK269962A	GSK269962A
+GSK650394	GSK650394
+GW441756	GW441756
+GW843682X	GW843682X
 Gadoinium	gadolinium
+Gaminocamptothecin	Aminocamptothecin
+Gamzar	Gemcitabine
 Gamzar	gemzar
-Gemar	NO-FIND
+Gefitinib	gefitinib
+Gemar	Gemcitabine
+Gemcitabine	Gemcitabine
+Gemcitabine (Gemzar)	Gemcitabine
+Gemcitabine HCI	Gemcitabine
+Gemcitabine HCL	Gemcitabine
+Gemcitabine Injection	Gemcitabine
+Gemcitabine and Cisplatin	Gemcitabine+Cisplatin
+Gemcitibane	Gemcitabine
 Gemcitibane	gemcitabine
+Gemcitibine	Gemcitabine
+Gemicitabine	Gemcitabine
 Gemicitabine	gemcitabine
+Gemox	Gemcitabine+Oxaliplatin
+Gemzan	Gemcitabine
 Gemzan	gemzar
+Gemzar	Gemcitabine
+Gemzar (Gemcitabine)	Gemcitabine
+Gemzet	Gemcitabine
 Genentech	NO-FIND
 Genentech Cpd	NO-FIND
 Genentech Cpd 10	NO-FIND
-Gezmar	NO-FIND
+Gezmar	Gemcitabine
+Gleevec	Imatinib
+Gliadel	Carmustine
+Gliadel Wafer	Carmustine
+Gliadel Wafers	Carmustine
+Gliadel wafers	Carmustine
+Gomzar	Gemcitabine
+Goserelin	Goserelin
+HEC.1 - Sorafenib vs Sorafenib plus Doxorubicin	HEC.1
+HERCEPTIN	Trastuzumab
+HERCPTIN	Trastuzumab
+HEXALEN	Altretamine
+HEXALIN	Altretamine
+HEXAMETHYLMELAMINE	Altretamine
+HEXAMETHYMELAMINE	Altretamine
+HEXLALEN	Altretamine
 HG-5-113-01	NO-FIND
 HG-5-88-01	NO-FIND
+HIGH DOSE INTERLEUKIN-2	Interleukin-2
+HSC vaccine injection	NOS
+HYDOXYUREA	Hydroxycarbamide
+HYDROCHOROQUINE	Hydroxychloroquine
+HYDROXUREA	Hydroxycarbamide
+HYDROXYUEREA	Hydroxycarbamide
+HYDROXYUREA	Hydroxycarbamide
+HYDROYUREA	Hydroxycarbamide
+HYRDROXYUREA	Hydroxycarbamide
+HYROXYUREA	Hydroxycarbamide
+Halaven	Eribulin
+Halichondrin	Halichondrin B
+Halichondrin B	Halichondrin B
+Herceptin	Trastuzumab
+Hexalen	Altretamine
+Hexalin	Altretamine
+Hexamethylmelamine	Altretamine
+Hexamethymelamine	Altretamine
 High dose	NO-FIND
+High dose Methotrexate w/ Leucovorin	Methotrexate+Leucovorin
+High dose ara-c	Cytarabine
 High dose ara-c	NO-FIND
+Hormone, NOS	NOS
+Hydoxyurea	Hydroxyurea
 Hydoxyurea	hydroxyurea
 Hydrochoroquine	hydroxychloroquine
+Hydrocortisone	Hydrocortisone
 Hydroxurea	hydroxyurea
+Hydroxydaunomycin	Doxorubicin
 Hydroxyuerea	hydroxyurea
+Hydroxyurea	Hydroxyurea
+Hydroyurea	Hydroxyurea
 Hydroyurea	hydroxyurea
 Hyrdroxyurea	hydroxyurea
 Hyroxyurea	hydroxyurea
+I 131 81C6	81C6
+I-131	Iodine-131
+I131-81C6	81C6
+ICE	Ifosfamide+Carboplatin+Etoposide
 ICT 107	NO-FIND
+ICT-107	ICT-107
 ICT-107	NO-FIND
+IFN-ALPHA (INTRON)	Hydroxycarbamide
+IFN-Alpha (Intron)	Interferon A
+IFOSFAMIDE	Ifosfamide
+IFOSTAMIDE	Ifosfamide
+IL 12	INTERLEUKIN-12
+IL 12	Interleukin-12
 IL 12	NO-FIND
+IL 13	INTERLEUKIN-13
 IL 13	NO-FIND
 IL 13PE	NO-FIND
-IL-2 (high dose)	NO-FIND
+IL 2	Aldesleukin
+IL 2	INTERLEUKIN-2
+IL-13 PSEUDOMONAS EXOTOXIN	IL-13 WITH PSEUDOMONAS EXOTOXIN
+IL-13 WITH PSEUDOMONAS EXOTOXIN	IL-13 WITH PSEUDOMONAS EXOTOXIN
+IL-13-PE38QQR CYTOXIN	IL-13 WITH PSEUDOMONAS EXOTOXIN
+IL-13PE	Cintredekin
+IL-13PE	IL-13 WITH PSEUDOMONAS EXOTOXIN
+IL-18	Interleukin-18
+IL-2	Aldesleukin
+IL-2	INTERLEUKIN-2
+IL-2 (HIGH DOSE)	INTERLEUKIN-2
+IL-2 (high dose)	Aldesleukin
+IL-2 THEARPY (INTERLEUKIN)	INTERLEUKIN-2
+IL-2 Therapy (interleukin)	Aldesleukin
+IL2	Aldesleukin
+IMATINIB	Imatinib
+IMC-A12	Cixutumumab
+INF	Infliximab
+INTERFERON	INTERFERON
+INTERFERON ALPHA	INTERFERON ALPHA
+INTERFERON GAMMA	INTERFERON GAMMA
+INTERFERON-ALPHA	INTERFERON ALPHA
+INTERLEUKIN 2-HIGH DOSE	INTERLEUKIN-2
+INTERLEUKIN-12	INTERLEUKIN-12
+INTERLEUKIN-2	INTERLEUKIN-2
+INVESTIGAL DRUG AVASTIN	Bevacizumab
+IPILIMUMAB	Ipilimumab
+IRESSA	Gefitinib
+IRESSA PLACEBO VS. DRUG	Gefitinib
+IRESSA placebo vs. drug	Gefitinib
+IRINOTEACAN	Irinotecan
+IRINOTECAN	Irinotecan
+IRINOTECAN HCL	Irinotecan
+IRINOTECAN+5-fluorouracilim	Irinotecan+Fluorouracil
+IRINOtecan HCl	Irinotecan
+IRINTOTECAN	Irinotecan
+IROLFLUVIN	Irolfluvin
+IRONOTECAN	Irinotecan
+IRRESSA	Gefitinib
+IRUNOTECAN	Irinotecan
+ISOTRECTINOIN (ACCCUTANE)	Isotretinoin
+ISOTRETINOIN	Isotretinoin
+IXABEPILONE	Ixabepilone
+Ibandronate	Ibandronate
+Ifex	Ifosfamide
+Ifosfamid	Ifosfamide
+Ifosfamide	Ifosfamide
+Ifostamide	Ifosfamide
 Ifostamide	ifosfamide
+Imatinib	Imatinib
+Imiquimod	Imiquimod
 Infusion	NO-FIND
 Inhibitor	NO-FIND
+Interferon	NOS
+Interferon Alpha	Interferon A
+Interferon alfa	Interferon A
+Interferon alfa-2b	Interferon A
+Interferon alpha	Interferon A
+Interferon gamma	Interferon G
+Interferon-?2	Aldesleukin
+Interferon-alfa	Interferon A
+Interleukin - 2	Aldesleukin
+Interleukin 2-high dose	Aldesleukin
+Interleukin-12	Interleukin-12
+Interleukin-2	Aldesleukin
+Intrathecal Methotrexate	Methotrexate
+Intron A	Interferon A
+Investigal drug Avastin	Bevacizumab
+Ipilimumab	Ipilimumab
+Iressa	Gefitinib
+Irinotecan	Irinotecan
+Irinotecan + Cetuximab	Irinotecan+Cetuximab
+Irinotecan HCL	Irinotecan
+Irinotecan HCl	Irinotecan
+Irinotecan Hydrochloride	Irinotecan
+Irintocean	Irinotecan
+Irintotecan	Irinotecan
 Irintotecan	irinotecan
+Irolfluvin	Irofulven
+Ironotecan	Irinotecan
 Ironotecan	irinotecan
+Irressa	Gefitinib
+Isotrectinoin (acccutane)	Isotretinoin
+Isotretinoin	Isotretinoin
+Ixabepilone	Ixabepilone
 JQ1 (1)	NO-FIND
 JQ1 (2)	NO-FIND
 JQ1 1	NO-FIND
 JQ1 2	NO-FIND
 JW-7-24-1	NO-FIND
 JW-7-52-1	NO-FIND
+JW7521	JW7521
+KARERLTECIN	karenitecin
+KETOCONAZOLE	Ketoconazole
 KIN001	NO-FIND
 KIN001 236	NO-FIND
 KIN001 244	NO-FIND
@@ -110,38 +831,304 @@ KIN001-244	NO-FIND
 KIN001-260	NO-FIND
 KIN001-266	NO-FIND
 KIN001-270	NO-FIND
+KIN001135	KIN001135
+KU55933	KU55933
+Karenitecin	Karenitecin
+Karerltecin	Karenitecin
+Ketoconazole	Ketoconazole
+LAPATINIB	LAPATINIB
+LENALIDOMIDE	Lenalidomide
+LETROZOLE	Letrozole
+LETROZOLE (FEMARA)	Letrozole
+LEUCOVORIN	Leucovorin
+LEUCOVORIN CALCIUM	Leucovorin
+LEUPROLIDE ACETATE (LUPRON)	Leuprolide
+LEUPRORELIN	Leuprorelin
+LEVCOVORIN	Leucovorin
+LEVENRACETAM	Levetiracetam
+LEVETIRACETAM	Levetiracetam
+LFMA13	LFMA13
+LHRH Agonist	LHRH
+LHRH Agonist and Anti-Androgens Combined Androgen Blockade	LHRH
+LIOSOMAL DOCORUBICIN	Liposomal doxorubicin
+LIPOSOMAL DOXORUBICAN	Liposomal doxorubicin
+LIPOSOMAL DOXORUBICIN	Liposomal doxorubicin
+LOMUSTIN	Lomustine
+LOMUSTINE	Lomustine
+LOMUSTINE (CCNU)	Lomustine
+LUMUSTINE	Lomustine
+LUPRON	Leuprolide
+LY228820	LY228820
+LY317615	Enzastaurin
+Laferon	Interferon A
+Lapatinib	Lapatinib
 Lestauritinib	lestaurtinib
+Letrozol	Letrozole
+Letrozole	Letrozole
+Letrozole (Femara)	Letrozole
+Leucovorin	Leucovorin
+Leucovorin Calcium	Leucovorin
+Leucovorin calcium	Leucovorin
+Leukine	Sargramostim
+Leuocvorin	Leucovorin
+Leuprolide	Leuprolide
+Leuprolide Acetate	Leuprolide
+Leuprolide acetate	Leuprolide
+Leuprorelin	Leuprolide
+Levcovorin	Leucovorin
 Levcovorin	leucovorin
+Levenracetam	Levetiracetam
+Levothroid	Levothyroxine
+Levothyroxine	Levothyroxine
+Levoxyl	Levothyroxine
 Liosomal	NO-FIND
+Liosomal Docorubicin	Doxorubicin
 Liposomal	liposomal vitamin c
+Liposomal Doxorubican	Doxorubicin
 Liposomal Doxorubican	liposomal doxorubicin
+Liposomal Doxorubicin	Doxorubicin
+Liposomal doxorubicin	Doxorubicin
+Lomustin	Lomustine
+Lomustine	Lomustine
+Lomustine (CCNU)	Lomustine
 Lumustine	lomustine
+Luprolide Depot	Leuprolide
+Lupron	Leuprolide
 Lymphocyte	NO-FIND
 Lymphocyte Infusion	NO-FIND
-MAB I	NO-FIND
+Lymphocyte Infusion	NOS
+MAB I	MABI131
+MAB I 131	MABI131
+MAB I-131	MABI131
+MAB I131	MABI131
+MABI131	MABI131
+MAGE-3	MAGE-3
 MAGE3	mage3 graphite
+MAGI131-81C6	MABI131
+MAGI131-81c6	81C6
+MARIMASTAT	Marimastat
 MAb I	NO-FIND
+MDX-1106 CLINICAL TRIAL	MDX-1106
+MDX-1106 clinical trial	Nivolumab
+MEGACE	Megestrol
+MEGACE (ORAL)	Megestrol
+MEL-44	Sargramostim
+MELPHALAN	Melphalan
+MELPHALON	Melphalan
+MESNA	Mesna
+MESNA-1	Mesna
+MESNA-2	Mesna
+METEXAFIN GADOLINIUM	MOTEXAFIN GADOLINIUM
+METFORMIN	Metformin
+METHOTREXATE	Methotrexate
+METRONOMIC TEMODAR	Temozolomide
+MG132	MG132
+MGI 114	Irofulven
+MGI 114	MGI-114
+MIDOSTAURIN	Midostaurin
+MITHRAMYCIN	Plicamycin
+MITOMYCIN C	Mitomycin
+MITOMYCINC	Mitomycin
+MITOXANTRONE	Mitoxantrone
+MK2206	MK-2206
+MK2206	MK2206
+MLN8237	Alisertib
+MORAb-004	MORAb-004
+MOTEXAFIN GADOLINIUM	Motexafin gadolinium
+MOTEXATIN GADOINIUM	Motexafin gadolinium
 MPS 1	NO-FIND
 MPS-1-IN-1	NO-FIND
+MR1-1	MR1-1
+MS275	Entinostat
+MU81C6	MU81C6
+Mage A3	MAGE-A3
 Mayo 425	NO-FIND
+Mayo 425-20	NOS
+Medrol	Methylprednisolone
+Megace	Megestrol
+Megace (oral)	Megestrol
+Megestrol Acetate	Megestrol
+Melphalan	Melphalan
+Melphalon	Melphalan
 Melphalon	melphalan
+Mesna	Mesna
+Metformin	Metformin
+Methotrexate	Methotrexate
+Mibefradil	mibefradil
+Micomycin	Mitomycin C
+Mithramycin	Plicamycin
+Mitomycin	Mitomycin C
+Mitomycin C	Mitomycin C
+Mitoxantrone	Mitoxantrone
+Motexatin Gadoinium	Motexafin gadolinium
 Multi	NO-FIND
+Mustophoran	Fotemustine
+NAB-RAPAMYCIN	Rapamycin
 NABIT	NO-FIND
 NABTT	NO-FIND
+NAVELBINE	Vinorelbine
+NEULASTA	Pegfilgrastim
+NEXAVAAR	Sorafenib
+NEXAVAR	Sorafenib
+NILOTINIB	Nilotinib
+NOLVADEX	Tamoxifen
 NPK76	NO-FIND
+NSC87877	NSC87877
+NU7441	NU7441
+NUTLIN3A	Nutlin-3A
+NVPBEZ235	NVPBEZ235
+NVPTAE684	NVPTAE684
+Navelbine	Vinorelbine
+Naxavar	Sorafenib
+Neulasta	Pegfilgrastim
+Nexavaar	Sorafenib
 Nexavaar	nexavar
+Nexavar	Sorafenib
+Nilutamide	Nilutamide
+Nimustine	Nimustine
+Nivolumab	Nivolumab
+Nolvadex	Tamoxifen
 Not otherwise	NO-FIND
 Not otherwise specified	NO-FIND
+Not otherwise specified	NOS
 Not specified	NO-FIND
-O ICE	NO-FIND
-O-ICE	NO-FIND
-PEP3 KLH	NO-FIND
-PTK ZK	NO-FIND
-PTK-ZK	NO-FIND
+Not specified	NOS
+O ICE	Ifosfamide+Carboplatin+Etoposide
+O-ICE	Ifosfamide+Carboplatin+Etoposide
+O6BG	O6BG
+OBATOCLAXMESYLATE	Obatoclax mesylate
+ONYX-015	ONYX-015
+ORAL ETOPOSIDE	Etoposide
+OS1-774	Tarceva
+OSI906	Linsitinib
+OVAREX MA6 B43.13	ovarex
+OVAREX STUDY	ovarex
+OVAREX/IND	ovarex
+OVAREX/PLACEBO	ovarex
+OXALIPLATIN	Oxaliplatin
+OXALIPLATINUM	Oxaliplatin
+OXCARBAZEPINE	Oxcarbazepine
+Oca Rex Oregovomab	Oregovomab
+Ofatumumab	Ofatumumab
+Oncophage	Vitespen
+Oncovin	Vincristine
+Oral Etoposide	Etoposide
+Ovarex MA6 B43.13	Oregovomab
+Ovarex Study	Oregovomab
+Ovarex/IND	Oregovomab
+Ovarex/Placebo	Oregovomab
+Ovarex/placebo	Oregovomab
+Oxaliplatin	Oxaliplatin
+Oxaliplatin, Folinic acid, Fluorouracil	Oxaliplatin+Leucovorin+Fluorouracil
+Oxaliplatinum	Oxaliplatin
+Oxaloplatin	Oxaliplatin
+PACILATXEL	Paclitaxel
+PACILTAXAL	Paclitaxel
+PACILTAXEL	Paclitaxel
+PACILTAXLE	Paclitaxel
+PACITAXEL	Paclitaxel
+PACLIATXEL	Paclitaxel
+PACLILTAXEL	Paclitaxel
+PACLITAXEL	Paclitaxel
+PACLITAXEL (PROTEIN-BOUND)	Paclitaxel
+PACLITAXEL; ALBUMIN-BOUNT	Paclitaxel
+PACLITAXIL	Paclitaxel
+PANITUMUMAB	Panitumumab
+PANZEM	Panzem
+PARAPLATIN	Carboplatin
+PARAPLATIN	PARAPLATIN
+PARTHENOLIDE	Parthenolide
+PATUPILONE	PATUPILONE
+PAXLITAXEL	Paclitaxel
+PAZOPANIB	Pazopanib
+PCV	Procarbazine+Lomustine+Vincristine
+PD 0332991	Palbociclib
+PD0325901	PD0325901
+PD0332991	PD0332991
+PD173074	PD173074
+PEGFILGRASTIM	Pegfilgrastim
+PEGFILGRASTIM (PEG G-CSF)	Pegfilgrastim
+PEMETHEXED	Pemetrexed
+PEMETREXED	Pemetrexed
+PEMETREXED DISODIUM	Pemetrexed
+PEP3 KLH	PEP-3-KLH
+PERIFOSINE	Perifosine
+PF02341066	crizotinib
+PF2341066	crizotinib
+PF562271	PF562271
+PHA665752	PHA665752
+PHENYTOIN SODIUM	PHENYTOIN SODIUM
+PI88	PI-88
+PLFE	PLFE
+PLFE/FLO	PLFE+Leucovorin+Fluorouracil+Oxaliplatin
+PLX4720	PLX4720
+PNU-159548	PNU-159548
+PORTEC3-radiation alone	NOS
+PREDNISONE	Prednisone
+PREMETREXED	Pemetrexed
+PROCARBAZINE	Procarbazine
+PROCARBAZINE/CCNU/VINCRISTINE	Procarbazine
+PROCARBIZINE	Procarbazine
+PROLEUKIN	Proleukin
+PROLEUKIN (IL-2)	Proleukin
+PROVERA	Medroxyprogesterone
+PS 341	Bortezomib
+PS-341 BORTREZOMIB	Bortezomib
+PS-341 Bortrezomib	Bortezomib
+PSC833	PSC833
+PSC833	Valspodar
+PSMA DNA Vaccine	PSMA DNA Vaccine
+PTK-ZK	Vatalanib
+PV-10	PV-10
+PYRAZINAMIDE	Pyrazinamide
+PYRIMETHAMINE	Pyrimethamine
+Pacilatxel	Paclitaxel
+Paciltaxal	Paclitaxel
+Paciltaxel	Paclitaxel
+Paciltaxle	Paclitaxel
+Pacitaxel	Paclitaxel
+Pacitaxol	Paclitaxel
+Pacliatxel	Paclitaxel
+Pacliltaxel	Paclitaxel
+Paclitaxel	Paclitaxel
+Paclitaxel (Protein-Bound)	Paclitaxel
+Paclitaxel; Albumin-Bount	Paclitaxel
+Paclitaxil	Paclitaxel
+Paclitaxol	Paclitaxel
+Palixtaxel	Paclitaxel
+Pamidronate	Pamidronate
+Pamidronic acid	Pamidronate
+Panitumumab	Panitumumab
+Paraplatin	Carboplatin
+Patrin	Lomeguatrib
+Patupilone	Patupilone
+Pazopanib	Pazopanib
+Pegfilgrastim	Pegfilgrastim
+Pegfilgrastim (Peg G-CSF)	Pegfilgrastim
+Pembrolizumab	Pembrolizumab
+Pemetrexed	Pemetrexed
+Pemetrexed (Alimta)	Pemetrexed
+Pemetrexed disodium	Pemetrexed
+Perifosine	Perifosine
 Placebo	NO-FIND
+Platinol	Cisplatin
+Platinum	Platinum
+Poly E	Poly E
+Polyplatillen	Cisplatin
+Porfimer Sodium (Photofin)	Porfimer
+Porfimer Sodium (Photofrin)	Porfimer
+Porfimer Sodium(Photofin)	Porfimer
 Posidum	NO-FIND
+Predisone	Prednisone
+Prednisolone	Prednisolone
+Prednisone	Prednisone
+Procarbazine	Procarbazine
+Procarbizine	Procarbazine
 Procarbizine	procarbazine
+Proleukin	Aldesleukin
 Protocol	NO-FIND
+Provera	Medroxyprogesterone
+Pyrazinamide	Pyrazinamide
 QL VIII	NO-FIND
 QL XI	NO-FIND
 QL XII	NO-FIND
@@ -150,35 +1137,249 @@ QL-X-138	NO-FIND
 QL-XI-92	NO-FIND
 QL-XII-47	NO-FIND
 QL-XII-61	NO-FIND
+R1507	Teprotumumab
+RAD001	Everolimus
+RAPAMCYIN	Sirolimus
+RAPAMYCIN	Sirolimus
+RBBX 01	RBBX 01
+RBBX 01	rBBX-01
+RDEA119	RDEA119
+REINOID/CIS RETINOIC ACID	Cis Retinoic Acid
+RITUXIMAB	Rituximab
+RO3306	RO3306
+ROFERON-A	ROFERON-A
+ROSCOVITINE	Seliciclib
+Raltitrexed	Raltitrexed
 Rapamcyin	rapamycin
 Ras Inhibitor	NO-FIND
+Regorafenib	Regorafenib
 Reinoid	retinoid
-Rhumab	NO-FIND
+Reinoid/CIS retinoic acid	retinoid
+RenAmin	Amino Acids
+Reolysin	Reolysin
+Resiquimod	Resiquimod
+Revlimid	Lenalidomide
+Rhumab	Erlizumab
+Rituxan	Rituximab
+Rituximab	Rituximab
+Roferon-A	Interferon A
+SAHA	Vorinostat
+SAHA/Vorinostat	Vorinostat
+SALUBRINAL	Salubrinal
+SARASAR	SARASAR
+SARGRAMOSTIN	SARGRAMOSTIN
+SB216763	SB216763
+SB590885	SB590885
 SCH 58500	NO-FIND
+SCH 58500	SCH 58500
+SCH 58500	SCH58500
+SCH63666	SCH63666
+SCH66336	Lonafarnib
+SCH6636	SCH6636
+SHIKONIN	Shikonin
+SIROLIMUS	Sirolimus
+SL01011	SL01011
+SNS 595	Voreloxin
+SNS 595	Vosaroxin
+SOM 230	Pasireotide
+SORAFENIB	Sorafenib
+SORAFENIB (BAY 43-9006)	Sorafenib
+SORAFENIB - NEXAVAR	Sorafenib
+SOVATENIB	Sorafenib
+STREPTOZOCIN	STREPTOZOCIN
+STRITYLLCYSTEINE	STRITYLLCYSTEINE
+STUDY DRUG AMG 655	NA
+SU101	leflunomide
+SUNITINIB	Sunitinib
+SUNITINIB (SUTENT)	Sunitinib
+SURAMIN	SURAMIN
+SUTENT	Sunitinib
+SUTENT (SUNITINIB)	Sunitinib
+SYNTHROID	Levothyroxine
+Sarafenib	Sorafenib
+Sargramostin	Sargramostim
 Sargramostin	sargramostim
+Sorafenib	Sorafenib
+Sorafenib (Bay 43-9006)	Sorafenib
+Sorafenib - Nexavar	Sorafenib
+Sorafinib ( Nexavar)	Sorafenib
 Study	NO-FIND
 Study drug	study drugs
+Study drug AMG 655	Conatumumab
+Sulindac	Sulindac
+Sunitinib	Sunitinib
+Suramin	Suramin
+Sutent	Sunitinib
+Sutent (Sunitinib)	Sunitinib
+Sylatron	Peginterferon alfa-2a
+Synthroid	Levothyroxine
+TAE684	NA
+TAMOXIFEN	Tamoxifen
+TAMOXIFEN & MEGACE	NA
+TAMOXIFEN (NOVADEX)	Tamoxifen
+TAMOXITEN	Tamoxifen
+TANCEVA	Erlotinib
+TARCEVA	Erlotinib
+TARVECA	Erlotinib
+TAXANE	NA
+TAXOL	Paclitaxel
+TAXOL OR TAXOTERE	NA
+TAXOL/CARBOPLATIN	Paclitaxel+Carboplatin
+TAXOTERE	Docetaxel
+TAXOTERECIN	Docetaxel
+TC	Docetaxel+Cyclophosphamide
+TCH	Docetaxel+Carboplatin+Trastuzumab
+TEMADOR	Temozolomide
+TEMAZOLOMIDE	Temozolomide
+TEMODAR	Temozolomide
+TEMODAR (ESCALATION)	Temozolomide
+TEMODOR	Temozolomide
+TEMOXOLOMIDE	Temozolomide
+TEMOZLOMIDE	Temozolomide
+TEMOZOLAMIDE	Temozolomide
+TEMOZOLOMIDE	Temozolomide
+TEMOZOLOMOIDE	Temozolomide
+TEMOZOMIDE	Temozolomide
+TEMSIROLIMUS	Temsirolimus
+TEMUDAR	Temozolomide
+THALIDOMIDE	Thalidomide
+THALOMID	Thalidomide
+THAPSIGARGIN	THAPSIGARGIN
+TIPFARNIB (R115777)	Tipifarnib
+TIPIFARNIB	Tipifarnib
+TIPIFARNIB (R115777)	Tipifarnib
 TL-1-85	NO-FIND
 TL-2-105	NO-FIND
+TL32711	Birinapant
+TOMAXIFEN	Tamoxifen
+TOPECAN	TOPOTECAN
+TOPETECAN	TOPOTECAN
+TOPOTECAN	TOPOTECAN
+TOPOTECAN HCL	TOPOTECAN
+TOPOTECAN/CARBOPLATIN	TOPOTECAN+CARBOPLATIN
+TOPTECAN	TOPOTECAN
+TORISEL	Temsirolimus
+TOXOTERE	Docetaxel
+TRABECTEDIN	Trabectedin
+TRANSTUZUMAB	TRASTUZUMAB
+TRASTUZUMAB	TRASTUZUMAB
+TRASTUZUMAB	Trastuzumab
+TRIPTORELIN	Triptorelin
+TS-1	Tegafur+Gimeracil+Oteracil
+Talimogene Laherparepvec (T-VEC)	Talimogene
+Tamoxifen	Tamoxifen
+Tamoxifen & Megace	Tamoxifen+Megestrol
+Tamoxiten	Tamoxifen
 Tamoxiten	tamoxifen
-Tanceva	NO-FIND
+Tanceva	Erlotinib
+Tarceva	Erlotinib
+Tarceva (Erlotinib)	Erlotinib
+Tarceva/Erlotinib	Erlotinib
 Tarveca	tarceva
+Taxane	NOS
+Taxel	Paclitaxel
+Taxol	Paclitaxel
+Taxol or Taxotere	NOS
+Taxol/Carboplatin	Paclitaxel+Carboplatin
+Taxotere	Docetaxel
+Taxotere/Cytoxan	Docetaxel+Cyclophosphamide
+Taxoterecin	Docetaxel
+Temazolomide	Temozolomide
 Temazolomide	temozolomide
+Temodal	Temozolomide
+Temodar	Temozolomide
 Temodor	temodar
 Temoxolomide	temozolomide
+Temozlomide	Temozolomide
 Temozlomide	temozolomide
+Temozolamide	Temozolomide
+Temozolomide	Temozolomide
 Temozolomode	temozolomide
+Temozomide	Temozolomide
 Temozomide	temozolomide
+Temsirolimus	Temsirolimus
+Teniposide	Teniposide
+Tesetaxel	Tesetaxel
+Tetrathiomolybdate	Tiomolibdate
+Thalidomide	Thalidomide
+Themozolomide	Temozolomide
 Thiguanine	thioguanine
+ThioTepa	Thiotepa
+Threshold-302	Evofosfamide
+Tipifarnib	Tipifarnib
+Tivantinib (ARQ-197)	Tivantinib
+Tivozanib	Tivozanib
+Tomaxifen	Tamoxifen
 Tomaxifen	tamoxifen
+Topecan	Topotecan
 Topecan	topotecan
+Topetecan	Topotecan
+Topotecan	Topotecan
+Topotecan HCL	Topotecan
+Topotecan HCl	Topotecan
+Topotecan/Carboplatin	Topotecan+Carboplatin
+Toptecan	Topotecan
 Toptecan	topotecan
+Torisel	Temsirolimus
+Trabectedin	Trabectedin
+Trametinib	Trametinib
+Trastuzumab	Trastuzumab
+Trelstar	Triptorelin
+Trenantone	Leuprolide
+Treosulfan	Treosulfan
+Triptorelin	Triptorelin
+Trustuzumab	Trastuzumab
 Trustuzumab	trastuzumab
+Tyrosine kinase inhibitor	NOS
+Unkown	NOS
+VALPROIC ACID	VALPROIC ACID
+VAMYDEX	VAMYDEX
+VANDETANIB	Vandetanib
+VATALANIB (PTK787)	Vatalanib
+VECTIBIX	Panitumumab
+VEGF-TRAP	Aflibercept
+VELCADE	Bortezomib
+VEMURAFENIB	Vemurafenib
+VINBLASTINE	VINBLASTINE
+VINCRISTIN	Vincristine
+VINCRISTINE	Vincristine
+VINORELBINE	Vinorelbine
+VINORELBINE TARTRATE	Vinorelbine
+VMCL	VMCL
 VNLG 124	NO-FIND
 VNLG/124	NO-FIND
+VORINOSTAT	Vorinostat
+VOTRIENT	Pazopanib
+VP 16	Etoposide
+VP 16 (ETOPOSIDE)	Etoposide
+VP-16	Etoposide
+VP16	Etoposide
+VX680	VX680
+VX702	VX702
 Vaccine	vaccine
+Valproic Acid	Valproic Acid
+Vamydex	Vamydex
+Velcade	Dortezomib
+Vemurafenib	Vemurafenib
+Vepesid	Etoposide
+Vinblastine	Vinblastine
+Vincristine	Vincristine
+Vincristine (sulfate)	Vincristine
+Vinorelbin	Vinorelbine
+Vinorelbin Tartrate	Vinorelbine
+Vinorelbine	Vinorelbine
+Vinorelbine Tartrate	Vinorelbine
+Vorinostat	Vorinostat
+Votrient	Pazopanib
+WH4023	WH4023
+WT-1 Vaccine	WT-1 Vaccine
 WZ-1-84	NO-FIND
+WZ184	WZ184
 Wafer	NO-FIND
+X17AAG	X17AAG
+X681640	X681640
+XELODA	Capecitabine
+XELODA (CAPECITABINE)	Capecitabine
 XMD11	NO-FIND
 XMD11 85h	NO-FIND
 XMD11-85h	NO-FIND
@@ -190,24 +1391,215 @@ XMD15 27	NO-FIND
 XMD15-27	NO-FIND
 XMD8 85	NO-FIND
 XMD8-85	NO-FIND
+XMD885	XMD885
+XYOTAX	paclitaxel poliglumex
+Xeloda	Capecitabine
+Xeloda (Capecitabine)	Capecitabine
+Xeloda(capecitabine)	Capecitabine
+Xelox	Capecitabine+Oxaliplatin
+Xgeva	Denosumab
+Xyotax	Paclitaxel
+Yervoy	Ipilimumab
+Yondelis	Trabectedin
+ZD6474	Vandetanib
 ZG 10	NO-FIND
 ZG-10	NO-FIND
+ZM447439	ZM447439
+ZOLADEX	goserelin
+ZOLEDRONIC ACID	Zoledronic acid
+ZOLEDRONIC ACID	zoledronate
+ZOLENDRONIC ACID	zoledronate
+ZOMETA	ZOMETA
+Zofran	Ondansetron
+Zoladex	Goserelin
+Zoledronic Acid	Zoledronic acid
+Zoledronic acid	Zoledronic acid
+Zometa	Zoledronic acid
+abraxane	Paclitaxel
+ac	Doxorubicin+Cyclophosphamide
 acccutane	accutane
+actinomycin d	Dactinomycin
+adriamicin	Doxorubicin
 adriamicin	adriamycin
+adriamycin	Doxorubicin
+adriamycin+cuclophosphamide	Doxorubicin+Cyclophosphamide
+adriamycin+cyclophosphamid	Doxorubicin+Cyclophosphamide
+adriamycin+cyclophosphamide	Doxorubicin+Cyclophosphamide
+adrimicin+cyclophosphamide	Doxorubicin+Cyclophosphamide
+adrimycin+cyclophosphamide	Doxorubicin+Cyclophosphamide
+alimta	Pemetrexed
 anastrazolum	anastrozole
+anastrozolum	Anastrozole
 anastrozolum	anastrozole
+arimidex	Anastrozole
+aromasin	Exemestane
+aromatase exemestane	Exemestane
+autologous vaccine	ATCV
+avastin	Bevacizumab
+azaTHIOprine	Azathioprine
+bevacizumab	Bevacizumab
+bleomycin	Bleomycin
+cabazitaxel	Cabazitaxel
+camptosar	Irinotecan
+capecitabine	Capecitabine
+carbopaltin	Carboplatin
+carboplatin	Carboplatin
+carboplatinum	Carboplatin
+casodex	Bicalutamide
+cetuximab	Cetuximab
+ciclofosfamida	Cyclophosphamide
+cis-retinoic acid	Isotretinoin
+cisplatim	Cisplatin
+cisplatin	Cisplatin
+cisplatinum	Cisplatin
+clodronate	Clodronate
+clodronic acid	Clodronate
+cyclophosphamid	Cyclophosphamide
+cyclophosphamide	Cyclophosphamide
+cyclophosphamide+methotrexatum+fluorouracillum	Cyclophosphamide+Methotrexatum+Fluorouracil
+cyclophosphamide, vincristine, and dacarbazine	Cyclophosphamide+Vincristine+Dacarbazine
+cyclophosphamidum	Cyclophosphamide
+cytarabine	Cytarabine
+cytomel	Liothyronine
+cytoxan	Cyclophosphamide
+dacarbazine	Dacarbazine
+dasatinib	Dasatinib
 dcVax	NO-FIND
+decadron	Dexamethasone
+degarelix	Degarelix
+dexamethasone	Dexamethasone
 discido	NO-FIND
-folinian	NO-FIND
-letrozolum	NO-FIND
-metotreksat	NO-FIND
+docetaxel	Docetaxel
+doxil	Doxorubicin
+doxorubicin	Doxorubicin
+doxorubicin HCL	Doxorubicin
+doxorubicin+ cyclophosphamide	Doxorubicin+Cyclophosphamide
+doxorubicin+cyclophosphamid	Doxorubicin+Cyclophosphamide
+doxorubicina	Doxorubicin
+doxorubicine	Doxorubicin
+doxorubicine cyclophosphamide tamoxifen	Doxorubicin+Cyclophosphamide+Tamoxifen
+doxorubicine+cyclophosphamide	Doxorubicin+Cyclophosphamide
+doxorubicine+cyclophosphamide+tamoxifen	Doxorubicin+Cyclophosphamide+Tamoxifen
+epirubicin	Epirubicin
+epirubicinum	Epirubicin
+erbitux	Cetuximab
+etoposide	Etoposide
+etoposide (VP-16)	Etoposide
+everolimus	Everolimus
+faslodex	Fulvestrant
+femara	Letrozole
+fluorouracil	Fluorouracil
+fluorouracilum	Fluorouracil
+folinian	Leucovorin
+folinic acid	Leucovorin
+fosaprepitant	Fosaprepitant
+fotemustine	Fotemustine
+fulvestrant	Fulvestrant
+gemcitabine	Gemcitabine
+gemcitabine HCL	Gemcitabine
+gemzar	Gemcitabine
+herceptin	Trastuzumab
+ifosfamide	Ifosfamide
+imatinib	Imatinib
+interferon	NOS
+interferon alpha	Interferon A
+interferon-alpha	Interferon A
+interleukin-2	Aldesleukin
+intrathecal methotrexate	Methotrexate
+intron a	Interferon A
+ipilimumab	Ipilimumab
+irinotecan	Irinotecan
+jevtana	Cabazitaxel
+ketoconazole	Ketoconazole
+lapatinib	Lapatinib
+letrozole	Letrozole
+letrozole femara	Letrozole
+letrozolum	Letrozole
+leucovorin	Leucovorin
+leucovorin calcium	Leucovorin
+leuprolide	Leuprolide
+levothyroxine	Levothyroxine
+levoxyl	Levothyroxine
+lomustine	Lomustine
+lupron	Leuprolide
+melphalan	Melphalan
+methotrexate	Methotrexate
+methotrexate+5 fluorouracil+cyclophosphamide	Methotrexate+Fluorouracil+Cyclophosphamide
+metilprednisona	Methylprednisolone
+metotreksat	Methotrexate
+mitotane	Mitotane
+nab-rapamycin	Rapamycin
 name	alias
+navelbine	Vinorelbine
+neulasta	Pegfilgrastim
+nivolumab	Nivolumab
+nolvadex	Tamoxifen
+oncophage vaccine	Vitespen
 otherwise	NO-FIND
-paclitaxelum	NO-FIND
+oxaliplatin	Oxaliplatin
+oxaliplatinum + 5-FU	Oxaliplatin+Fluorouracil
+oxaliplatinum+ 5-FU	Oxaliplatin+Fluorouracil
+oxaliplatinum+5 fluorouracilum	Oxaliplatin+Fluorouracil
+oxaliplatinum+5-FU	Oxaliplatin+Fluorouracil
+paclitaxel	Paclitaxel
+paclitaxelum	Paclitaxel
+panitumumab	Panitumumab
+pazopanib	Pazopanib
+pembrolizumab	Pembrolizumab
+pemetrexed	Pemetrexed
+pemetrexed disodium	Pemetrexed
+platinum	Platinum
+prednisona	Prednisone
+premetrexed	Pemetrexed
+procarbazine	Procarbazine
+proleukin (IL-2)	Aldesleukin
+px-866	px-866
 rTRAIL	trail blazers
-rec MAGE	NO-FIND
+raloxifene	Raloxifene
+rec MAGE	MAGE-3-AS-AS15-ASCI
+rec MAGE 3-AS + AS15 ACS1 / Placebo Vaccine	MAGE-3-AS-AS15-ASCI
+rec MAGE3-AS+AS15 ASCI vs Placebo	MAGE-3-AS-AS15-ASCI
+recMAGE- A3	MAGE-A3
+recMAGE3-AS+AS15 ASCI/Placebo vaccine	MAGE-3-AS-AS15-ASCI
+recPRAME+AS15	GSK2302025A
+recPRAME+AS15 ASCI	GSK2302025A
+regorafenib	Regorafenib
 retinoic	retinoic acid
+rigosertib	Rigosertib
+rituximab	Rituximab
+sorafenib	Sorafenib
 specified	NO-FIND
+streptozocin	Streptozocin
+sunitinib	Sunitinib
+sunitinib (sutent)	Sunitinib
+sutent	Sunitinib
+sutent (sunitinib)	Sunitinib
+synthroid	Levothyroxine
+tamoxifen	Tamoxifen
+tamoxifen citrate	Tamoxifen
 tamoxiphen	tamoxifen
+tamoxiphen+anastrazolum	Tamoxifen+Anastrozole
+tamoxiphene	Tamoxifen
 tamoxiphene	tamoxifen
+tamoxiphene+anastrozolum	Tamoxifen+Anastrozole
+tamoxiphene+leuporeline+gosereline	Tamoxifen+Leuprolide+Goserelin
+taxol	Paclitaxel
+taxol+adriamycin+cyclophosphamide+herceptin	Paclitaxel+Doxorubicin+Cyclophosphamide+Trastuzumab
+taxotere	Docetaxel
+tc	Docetaxel+Cyclophosphamide
+temodar	Temozolomide
+temozolomide	Temozolomide
+temsirolimus	Temsirolimus
+thalidomide	Thalidomide
+topotecan	Topotecan
+trabectedin	Trabectedin
+trastuzumab	Trastuzumab
+triptorelin	Triptorelin
 vaccine	vaccine
+vectibix	Panitumumab
+vemurafenib	Vemurafenib
+vinblastine	Vinblastine
+vincristina	Vincristine
+vincristine	Vincristine
+xeloda	Capecitabine
+zoledronic acid	Zoledronic acid

--- a/tests/unit/enrichers/test_drug_enricher.py
+++ b/tests/unit/enrichers/test_drug_enricher.py
@@ -15,6 +15,8 @@ AKT inhibitor VIII (1)
 Ecotrin
 Tomaxifen
 Tamoxiten
+Abagovomag
+Zometa
 """.strip().split("\n")
 
 EXPECTED = [
@@ -30,6 +32,8 @@ EXPECTED = [
     [{'ontology_term': 'CID2244', 'source': 'http://rdf.ncbi.nlm.nih.gov/pubchem/compound', 'synonym': 'aspirin'}],
     [{'approved_countries': ['Canada', 'US'], 'ontology_term': 'CID2733526', 'source': 'http://rdf.ncbi.nlm.nih.gov/pubchem/compound', 'synonym': 'Tamoxifen', 'taxonomy': {'class': 'Stilbenes', 'direct-parent': 'Stilbenes', 'kingdom': 'Organic compounds', 'superclass': 'Phenylpropanoids and polyketides'}, 'toxicity': 'Signs observed at the highest doses following studies to ' 'determine LD<sub>50</sub> in animals were respiratory ' 'difficulties and convulsions.'}],
     [{'approved_countries': ['Canada', 'US'], 'ontology_term': 'CID2733526', 'source': 'http://rdf.ncbi.nlm.nih.gov/pubchem/compound', 'synonym': 'Tamoxifen', 'taxonomy': {'class': 'Stilbenes', 'direct-parent': 'Stilbenes', 'kingdom': 'Organic compounds', 'superclass': 'Phenylpropanoids and polyketides'}, 'toxicity': 'Signs observed at the highest doses following studies to ' 'determine LD<sub>50</sub> in animals were respiratory ' 'difficulties and convulsions.'}],
+    [{'ontology_term': 'CHEMBL1742981', 'source': 'http://rdf.ebi.ac.uk/terms/chembl', 'synonym': 'Abagovomab', 'usan_stem': 'monoclonal antibodies'}],
+    [{'ontology_term': 'CID68740', 'source': 'http://rdf.ncbi.nlm.nih.gov/pubchem/compound', 'synonym': 'Zoledronic acid'}],
 ]
 
 
@@ -51,9 +55,9 @@ def test_simple(caplog):
 
 def test_alias():
     assert 'Tomaxifen' in drug_enricher.ALIASES, 'we should have an alias for Tomaxifen'
-    assert drug_enricher.ALIASES['Tomaxifen'] == 'tamoxifen', 'the alias for Tomaxifen should be tamoxifen'
+    assert drug_enricher.ALIASES['Tomaxifen'].lower() == 'tamoxifen', 'the alias for Tomaxifen should be tamoxifen'
     assert 'Tamoxiten' in drug_enricher.ALIASES, 'we should have an alias for Tamoxiten'
-    assert drug_enricher.ALIASES['Tamoxiten'] == 'tamoxifen', 'the alias for Tamoxiten should be tamoxifen'
+    assert drug_enricher.ALIASES['Tamoxiten'].lower() == 'tamoxifen', 'the alias for Tamoxiten should be tamoxifen'
 
 
 def test_spell_check():


### PR DESCRIPTION
This PR increases the number of compounds that have a recognized ontology.
The drug_alias.tsv was expanded by merging in other alias [tsv](https://github.com/jguinney/virtualIC50/blob/master/resources/compounds.txt) and [csv](https://gdisc.bme.gatech.edu/cgi-bin/gdisc/tap5.cgi)  sources.

```
$ ~/bin/swift stat bmeg source/drug_enricher/drug_alias.tsv | grep ETag
          ETag: a50e11d8583103111b899449f31979b1

$ ~/bin/swift stat bmeg source/compound/sqlite.db | grep ETag
          ETag: 6801067188f5d9aa27c87f7af45a720c
```