### PR TITLE
Pathway Commons Import

### DIFF
--- a/outputs-pc.pathway-commons.dvc
+++ b/outputs-pc.pathway-commons.dvc
@@ -1,0 +1,12 @@
+cmd: ' grip rdf --dump --gzip outputs-pc/pathway-commons source/pathway_commons/PathwayCommons10.All.BIOPAX.owl.gz'
+deps:
+- md5: 5678579014a1721824696e66a21e9c7f
+  path: source/pathway_commons/PathwayCommons10.All.BIOPAX.owl.gz
+md5: 1db3fd8d879472e7568c99a589bb74b9
+outs:
+- cache: true
+  md5: 315c30f413a262cb2146643925ab5ac0
+  path: outputs-pc/pathway-commons.edge.json
+- cache: true
+  md5: e9929e1961a31238c9f7b23647c0d21a
+  path: outputs-pc/pathway-commons.vertex.json

--- a/outputs-pc/.gitignore
+++ b/outputs-pc/.gitignore
@@ -1,0 +1,2 @@
+/pathway-commons.edge.json
+/pathway-commons.vertex.json

--- a/source.pathway_commons.dvc
+++ b/source.pathway_commons.dvc
@@ -1,0 +1,9 @@
+cmd: ' curl -o source/pathway_commons/PathwayCommons10.All.BIOPAX.owl.gz http://www.pathwaycommons.org/archives/PC2/v10/PathwayCommons10.All.BIOPAX.owl.gz'
+deps:
+- md5: d41d8cd98f00b204e9800998ecf8427e
+  path: source/pathway_commons/version
+md5: 03bf6942a31e636fc768ff6b35c1086a
+outs:
+- cache: true
+  md5: 5678579014a1721824696e66a21e9c7f
+  path: source/pathway_commons/PathwayCommons10.All.BIOPAX.owl.gz


### PR DESCRIPTION
This is the commands to download Pathway Commons and turn into a property graph. 
This is not part of the BMEG, but rather a second graph that can be served on the GRIP server. 