### PR TITLE
Fix/regex match

### DIFF
--- a/schema/Citation.yaml
+++ b/schema/Citation.yaml
@@ -55,6 +55,2879 @@ links:
     id: /useContext/-/valueReference/reference
   templateRequired:
   - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Timing
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SampledDat
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Observation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Phenotype
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientLink
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Patient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Annotation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Substance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_UsageContext
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Allele
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Period
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Protein
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Gene
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Task
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Range
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientContact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Condition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Citation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Attachment
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Mone
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Encounter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_RatioRange
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Resource
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Procedure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Distance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Methylation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Interaction
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Address
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Expression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Reference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Transcript
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Availabilit
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Count
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Quantit
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneSet
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Narrative
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Signature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Dosage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Specimen
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Extension
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_HumanName
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Met
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Pathw
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Identifier
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskInput
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Medication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Publication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Exon
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Age
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Duration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Ratio
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Coding
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_citation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
 properties:
   _approvalDate:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/Citation.yaml
+++ b/schema/Citation.yaml
@@ -124,7 +124,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -133,9 +133,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -175,7 +175,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SampledDat
+  rel: relatedArtifact_resourceReference_SampledData
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -184,9 +184,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -209,7 +209,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_FamilyMemberHistor
+  rel: relatedArtifact_resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -218,9 +218,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -277,7 +277,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ObservationTriggeredB
+  rel: relatedArtifact_resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -286,9 +286,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -447,7 +447,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionPropert
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -456,9 +456,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -719,7 +719,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -728,9 +728,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -770,7 +770,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ExtendedContactDetai
+  rel: relatedArtifact_resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -779,9 +779,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -974,7 +974,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -983,9 +983,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1212,7 +1212,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1221,15 +1221,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationSummar
+  rel: relatedArtifact_resourceReference_CitationSummary
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1238,15 +1238,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Mone
+  rel: relatedArtifact_resourceReference_Money
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1255,9 +1255,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1297,7 +1297,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1306,9 +1306,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1433,7 +1433,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_GeneOntologyTer
+  rel: relatedArtifact_resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1442,9 +1442,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1569,7 +1569,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ContactDetai
+  rel: relatedArtifact_resourceReference_ContactDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1578,9 +1578,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1603,7 +1603,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1612,15 +1612,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStudyLabe
+  rel: relatedArtifact_resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1629,9 +1629,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1722,7 +1722,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1731,9 +1731,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1756,7 +1756,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ImagingStud
+  rel: relatedArtifact_resourceReference_ImagingStudy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -1765,9 +1765,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1994,7 +1994,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2003,15 +2003,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Availabilit
+  rel: relatedArtifact_resourceReference_Availability
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2020,9 +2020,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2045,7 +2045,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Quantit
+  rel: relatedArtifact_resourceReference_Quantity
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2054,9 +2054,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2181,7 +2181,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_VirtualServiceDetai
+  rel: relatedArtifact_resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2190,15 +2190,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStud
+  rel: relatedArtifact_resourceReference_ResearchStudy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2207,9 +2207,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2487,7 +2487,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Met
+  rel: relatedArtifact_resourceReference_Meta
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2496,9 +2496,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2555,7 +2555,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Pathw
+  rel: relatedArtifact_resourceReference_Pathway
   targetHints:
     backref:
     - relatedArtifact_resourceReference_citation
@@ -2564,9 +2564,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:

--- a/schema/DocumentReference.yaml
+++ b/schema/DocumentReference.yaml
@@ -87,6 +87,2879 @@ links:
     id: /relatesTo/-/target/reference
   templateRequired:
   - id
+- href: id
+  rel: subject_MedicationAdministration
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DocumentReference
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TaskPerformer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Timing
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SampledDat
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_FamilyMemberHistor
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_RelatedArtifact
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Observation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ObservationTriggeredB
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Phenotype
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_PatientLink
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TaskOutput
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Patient
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Annotation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Substance
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_UsageContext
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CodeableReference
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Allele
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ProteinStructure
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationRequest
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Period
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_EncounterParticipant
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ConditionParticipant
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CopyNumberAlteration
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ExtendedContactDetai
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Protein
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DataRequirementSort
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ImagingStudySeries
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_GenomicFeature
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifact
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationStatement
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Gene
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Task
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Range
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_PatientContact
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DataRequirement
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Condition
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Citation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SpecimenCollection
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Attachment
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationIngredient
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationSummar
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Mone
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Encounter
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TaskRestriction
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_RatioRange
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SomaticVariant
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TranscriptExpression
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MethylationProbe
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_GeneOntologyTer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationClassification
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Resource
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_GeneExpression
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DosageDoseAndRate
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ObservationReferenceRange
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ContactDetai
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Procedure
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyLabe
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyObjective
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ProcedurePerformer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Distance
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationStatusDate
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ImagingStud
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Methylation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Interaction
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SomaticCallset
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ObservationComponent
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Address
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Expression
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceIngredient
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_EncounterLocation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_EncounterDiagnosis
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Reference
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Transcript
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Availabilit
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Count
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Quantit
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_GeneSet
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Narrative
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SpecimenFeature
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DocumentReferenceContent
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_EncounterAdmission
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_VirtualServiceDetai
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStud
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_EncounterReason
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Signature
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Dosage
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_PatientCommunication
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Specimen
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SpecimenContainer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Extension
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_DrugResponse
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_HumanName
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TriggerDefinition
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Met
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_AlleleEffect
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Pathw
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Identifier
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TaskInput
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Medication
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_MedicationBatch
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ResearchSubject
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Publication
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CodeableConcept
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ContactPoint
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Exon
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Age
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinition
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ConditionStage
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Duration
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SpecimenProcessing
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Ratio
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_ParameterDefinition
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_Coding
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
+- href: id
+  rel: subject_TimingRepeat
+  targetHints:
+    backref:
+    - subject_documentreference
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /subject/reference
+  templateRequired:
+  - id
 properties:
   _date:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/DocumentReference.yaml
+++ b/schema/DocumentReference.yaml
@@ -156,7 +156,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_CitationCitedArtifactContributorshipEntr
+  rel: subject_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - subject_documentreference
@@ -165,9 +165,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -207,7 +207,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_SampledDat
+  rel: subject_SampledData
   targetHints:
     backref:
     - subject_documentreference
@@ -216,9 +216,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -241,7 +241,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_FamilyMemberHistor
+  rel: subject_FamilyMemberHistory
   targetHints:
     backref:
     - subject_documentreference
@@ -250,9 +250,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -309,7 +309,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_ObservationTriggeredB
+  rel: subject_ObservationTriggeredBy
   targetHints:
     backref:
     - subject_documentreference
@@ -318,9 +318,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -479,7 +479,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_SubstanceDefinitionPropert
+  rel: subject_SubstanceDefinitionProperty
   targetHints:
     backref:
     - subject_documentreference
@@ -488,9 +488,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -751,7 +751,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_SubstanceDefinitionSourceMateri
+  rel: subject_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - subject_documentreference
@@ -760,9 +760,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -802,7 +802,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_ExtendedContactDetai
+  rel: subject_ExtendedContactDetail
   targetHints:
     backref:
     - subject_documentreference
@@ -811,9 +811,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1006,7 +1006,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_ResearchStudyAssociatedPart
+  rel: subject_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - subject_documentreference
@@ -1015,9 +1015,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1244,7 +1244,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_SubstanceDefinitionNameOffici
+  rel: subject_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - subject_documentreference
@@ -1253,15 +1253,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
   - id
 - href: id
-  rel: subject_CitationSummar
+  rel: subject_CitationSummary
   targetHints:
     backref:
     - subject_documentreference
@@ -1270,15 +1270,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
   - id
 - href: id
-  rel: subject_Mone
+  rel: subject_Money
   targetHints:
     backref:
     - subject_documentreference
@@ -1287,9 +1287,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1329,7 +1329,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_CitationCitedArtifactPublicationFor
+  rel: subject_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - subject_documentreference
@@ -1338,9 +1338,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1465,7 +1465,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_GeneOntologyTer
+  rel: subject_GeneOntologyTerm
   targetHints:
     backref:
     - subject_documentreference
@@ -1474,9 +1474,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1601,7 +1601,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_ContactDetai
+  rel: subject_ContactDetail
   targetHints:
     backref:
     - subject_documentreference
@@ -1610,9 +1610,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1635,7 +1635,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_MedicationRequestDispenseRequestInitialFi
+  rel: subject_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - subject_documentreference
@@ -1644,15 +1644,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
   - id
 - href: id
-  rel: subject_ResearchStudyLabe
+  rel: subject_ResearchStudyLabel
   targetHints:
     backref:
     - subject_documentreference
@@ -1661,9 +1661,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1754,7 +1754,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_CitationCitedArtifactContributorshipSummar
+  rel: subject_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - subject_documentreference
@@ -1763,9 +1763,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -1788,7 +1788,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_ImagingStud
+  rel: subject_ImagingStudy
   targetHints:
     backref:
     - subject_documentreference
@@ -1797,9 +1797,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -2026,7 +2026,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_SubstanceDefinitionMoiet
+  rel: subject_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - subject_documentreference
@@ -2035,15 +2035,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
   - id
 - href: id
-  rel: subject_Availabilit
+  rel: subject_Availability
   targetHints:
     backref:
     - subject_documentreference
@@ -2052,9 +2052,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -2077,7 +2077,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_Quantit
+  rel: subject_Quantity
   targetHints:
     backref:
     - subject_documentreference
@@ -2086,9 +2086,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -2213,7 +2213,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_VirtualServiceDetai
+  rel: subject_VirtualServiceDetail
   targetHints:
     backref:
     - subject_documentreference
@@ -2222,15 +2222,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
   - id
 - href: id
-  rel: subject_ResearchStud
+  rel: subject_ResearchStudy
   targetHints:
     backref:
     - subject_documentreference
@@ -2239,9 +2239,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -2519,7 +2519,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_Met
+  rel: subject_Meta
   targetHints:
     backref:
     - subject_documentreference
@@ -2528,9 +2528,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:
@@ -2587,7 +2587,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: subject_Pathw
+  rel: subject_Pathway
   targetHints:
     backref:
     - subject_documentreference
@@ -2596,9 +2596,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /subject/reference
   templateRequired:

--- a/schema/Extension.yaml
+++ b/schema/Extension.yaml
@@ -83,6 +83,2879 @@ links:
     id: /valueUsageContext/valueReference/reference
   templateRequired:
   - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Timing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SampledDat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Observation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Phenotype
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientLink
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Patient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Annotation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Substance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_UsageContext
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Allele
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Period
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Protein
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Gene
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Task
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Range
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientContact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Condition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Citation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Attachment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Mone
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Encounter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RatioRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Resource
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Procedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Distance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Methylation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Interaction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Address
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Expression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Reference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Transcript
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Availabilit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Count
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Quantit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneSet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Narrative
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Signature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Dosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Specimen
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Extension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_HumanName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Met
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Pathw
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Identifier
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskInput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Medication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Publication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Exon
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Age
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Duration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Ratio
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Coding
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_extension
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
 properties:
   extension:
     description: May be used to represent additional information that is not part

--- a/schema/Extension.yaml
+++ b/schema/Extension.yaml
@@ -152,7 +152,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -161,9 +161,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -203,7 +203,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SampledDat
+  rel: valueRelatedArtifact_resourceReference_SampledData
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -212,9 +212,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -237,7 +237,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -246,9 +246,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -305,7 +305,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -314,9 +314,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -475,7 +475,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -484,9 +484,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -747,7 +747,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -756,9 +756,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -798,7 +798,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -807,9 +807,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1002,7 +1002,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1011,9 +1011,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1240,7 +1240,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1249,15 +1249,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  rel: valueRelatedArtifact_resourceReference_CitationSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1266,15 +1266,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Mone
+  rel: valueRelatedArtifact_resourceReference_Money
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1283,9 +1283,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1325,7 +1325,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1334,9 +1334,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1461,7 +1461,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1470,9 +1470,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1597,7 +1597,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  rel: valueRelatedArtifact_resourceReference_ContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1606,9 +1606,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1631,7 +1631,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1640,15 +1640,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1657,9 +1657,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1750,7 +1750,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1759,9 +1759,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1784,7 +1784,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  rel: valueRelatedArtifact_resourceReference_ImagingStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -1793,9 +1793,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2022,7 +2022,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2031,15 +2031,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Availabilit
+  rel: valueRelatedArtifact_resourceReference_Availability
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2048,9 +2048,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2073,7 +2073,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Quantit
+  rel: valueRelatedArtifact_resourceReference_Quantity
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2082,9 +2082,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2209,7 +2209,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2218,15 +2218,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  rel: valueRelatedArtifact_resourceReference_ResearchStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2235,9 +2235,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2515,7 +2515,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Met
+  rel: valueRelatedArtifact_resourceReference_Meta
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2524,9 +2524,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2583,7 +2583,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Pathw
+  rel: valueRelatedArtifact_resourceReference_Pathway
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_extension
@@ -2592,9 +2592,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:

--- a/schema/MedicationAdministration.yaml
+++ b/schema/MedicationAdministration.yaml
@@ -151,7 +151,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactContributorshipEntr
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -160,9 +160,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -202,7 +202,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SampledDat
+  rel: supportingInformation_SampledData
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -211,9 +211,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -236,7 +236,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_FamilyMemberHistor
+  rel: supportingInformation_FamilyMemberHistory
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -245,9 +245,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -304,7 +304,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ObservationTriggeredB
+  rel: supportingInformation_ObservationTriggeredBy
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -313,9 +313,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -474,7 +474,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionPropert
+  rel: supportingInformation_SubstanceDefinitionProperty
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -483,9 +483,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -746,7 +746,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionSourceMateri
+  rel: supportingInformation_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -755,9 +755,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -797,7 +797,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ExtendedContactDetai
+  rel: supportingInformation_ExtendedContactDetail
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -806,9 +806,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1001,7 +1001,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStudyAssociatedPart
+  rel: supportingInformation_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1010,9 +1010,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1239,7 +1239,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionNameOffici
+  rel: supportingInformation_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1248,15 +1248,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationSummar
+  rel: supportingInformation_CitationSummary
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1265,15 +1265,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Mone
+  rel: supportingInformation_Money
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1282,9 +1282,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1324,7 +1324,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactPublicationFor
+  rel: supportingInformation_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1333,9 +1333,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1460,7 +1460,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_GeneOntologyTer
+  rel: supportingInformation_GeneOntologyTerm
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1469,9 +1469,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1596,7 +1596,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ContactDetai
+  rel: supportingInformation_ContactDetail
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1605,9 +1605,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1630,7 +1630,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_MedicationRequestDispenseRequestInitialFi
+  rel: supportingInformation_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1639,15 +1639,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStudyLabe
+  rel: supportingInformation_ResearchStudyLabel
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1656,9 +1656,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1749,7 +1749,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactContributorshipSummar
+  rel: supportingInformation_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1758,9 +1758,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1783,7 +1783,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ImagingStud
+  rel: supportingInformation_ImagingStudy
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -1792,9 +1792,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2021,7 +2021,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionMoiet
+  rel: supportingInformation_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2030,15 +2030,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Availabilit
+  rel: supportingInformation_Availability
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2047,9 +2047,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2072,7 +2072,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Quantit
+  rel: supportingInformation_Quantity
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2081,9 +2081,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2208,7 +2208,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_VirtualServiceDetai
+  rel: supportingInformation_VirtualServiceDetail
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2217,15 +2217,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStud
+  rel: supportingInformation_ResearchStudy
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2234,9 +2234,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2514,7 +2514,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Met
+  rel: supportingInformation_Meta
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2523,9 +2523,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2582,7 +2582,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Pathw
+  rel: supportingInformation_Pathway
   targetHints:
     backref:
     - supportingInformation_medicationadministration
@@ -2591,9 +2591,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:

--- a/schema/MedicationAdministration.yaml
+++ b/schema/MedicationAdministration.yaml
@@ -82,6 +82,2879 @@ links:
     id: /note/-/authorReference/reference
   templateRequired:
   - id
+- href: id
+  rel: supportingInformation_MedicationAdministration
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReference
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Timing
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SampledDat
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistor
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_RelatedArtifact
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Observation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationTriggeredB
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Phenotype
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientLink
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskOutput
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Patient
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Annotation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Substance
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_UsageContext
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CodeableReference
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Allele
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProteinStructure
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequest
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Period
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ConditionParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CopyNumberAlteration
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ExtendedContactDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Protein
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementSort
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeries
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GenomicFeature
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifact
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationStatement
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Gene
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Task
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Range
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientContact
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirement
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Condition
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Citation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenCollection
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Attachment
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationIngredient
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationSummar
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Mone
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Encounter
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskRestriction
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_RatioRange
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SomaticVariant
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TranscriptExpression
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MethylationProbe
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneOntologyTer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationClassification
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Resource
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneExpression
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DosageDoseAndRate
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationReferenceRange
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ContactDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Procedure
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyLabe
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyObjective
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProcedurePerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Distance
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationStatusDate
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStud
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Methylation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Interaction
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SomaticCallset
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationComponent
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Address
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Expression
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceIngredient
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterLocation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterDiagnosis
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Reference
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Transcript
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Availabilit
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Count
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Quantit
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneSet
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Narrative
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenFeature
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceContent
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterAdmission
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_VirtualServiceDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStud
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterReason
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Signature
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Dosage
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientCommunication
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Specimen
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenContainer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Extension
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DrugResponse
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_HumanName
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TriggerDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Met
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AlleleEffect
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Pathw
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Identifier
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskInput
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Medication
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationBatch
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchSubject
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Publication
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CodeableConcept
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ContactPoint
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Exon
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Age
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ConditionStage
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Duration
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenProcessing
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Ratio
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ParameterDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Coding
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TimingRepeat
+  targetHints:
+    backref:
+    - supportingInformation_medicationadministration
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
 properties:
   _implicitRules:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/MedicationRequest.yaml
+++ b/schema/MedicationRequest.yaml
@@ -127,6 +127,2879 @@ links:
     id: /note/-/authorReference/reference
   templateRequired:
   - id
+- href: id
+  rel: supportingInformation_MedicationAdministration
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReference
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Timing
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SampledDat
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistor
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_RelatedArtifact
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Observation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationTriggeredB
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Phenotype
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientLink
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskOutput
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Patient
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Annotation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Substance
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_UsageContext
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CodeableReference
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Allele
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProteinStructure
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequest
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Period
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ConditionParticipant
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CopyNumberAlteration
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ExtendedContactDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Protein
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementSort
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeries
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GenomicFeature
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifact
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationStatement
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Gene
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Task
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Range
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientContact
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirement
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Condition
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Citation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenCollection
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Attachment
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationIngredient
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationSummar
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Mone
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Encounter
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskRestriction
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_RatioRange
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SomaticVariant
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TranscriptExpression
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MethylationProbe
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneOntologyTer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationClassification
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Resource
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneExpression
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DosageDoseAndRate
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationReferenceRange
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ContactDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Procedure
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyLabe
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyObjective
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProcedurePerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Distance
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationStatusDate
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ImagingStud
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Methylation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Interaction
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SomaticCallset
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ObservationComponent
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Address
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Expression
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceIngredient
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterLocation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterDiagnosis
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Reference
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Transcript
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Availabilit
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Count
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Quantit
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_GeneSet
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Narrative
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenFeature
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DocumentReferenceContent
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterAdmission
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_VirtualServiceDetai
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStud
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_EncounterReason
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Signature
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Dosage
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_PatientCommunication
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Specimen
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenContainer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Extension
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_DrugResponse
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_HumanName
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TriggerDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Met
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_AlleleEffect
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Pathw
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Identifier
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TaskInput
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Medication
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_MedicationBatch
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ResearchSubject
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Publication
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CodeableConcept
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ContactPoint
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Exon
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Age
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ConditionStage
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Duration
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SpecimenProcessing
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Ratio
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_ParameterDefinition
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_Coding
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInformation_TimingRepeat
+  targetHints:
+    backref:
+    - supportingInformation_medicationrequest
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /supportingInformation/-/reference
+  templateRequired:
+  - id
 properties:
   _authoredOn:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/MedicationRequest.yaml
+++ b/schema/MedicationRequest.yaml
@@ -196,7 +196,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactContributorshipEntr
+  rel: supportingInformation_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -205,9 +205,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -247,7 +247,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SampledDat
+  rel: supportingInformation_SampledData
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -256,9 +256,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -281,7 +281,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_FamilyMemberHistor
+  rel: supportingInformation_FamilyMemberHistory
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -290,9 +290,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -349,7 +349,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ObservationTriggeredB
+  rel: supportingInformation_ObservationTriggeredBy
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -358,9 +358,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -519,7 +519,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionPropert
+  rel: supportingInformation_SubstanceDefinitionProperty
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -528,9 +528,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -791,7 +791,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionSourceMateri
+  rel: supportingInformation_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -800,9 +800,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -842,7 +842,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ExtendedContactDetai
+  rel: supportingInformation_ExtendedContactDetail
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -851,9 +851,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1046,7 +1046,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStudyAssociatedPart
+  rel: supportingInformation_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1055,9 +1055,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1284,7 +1284,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionNameOffici
+  rel: supportingInformation_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1293,15 +1293,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationSummar
+  rel: supportingInformation_CitationSummary
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1310,15 +1310,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Mone
+  rel: supportingInformation_Money
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1327,9 +1327,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1369,7 +1369,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactPublicationFor
+  rel: supportingInformation_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1378,9 +1378,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1505,7 +1505,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_GeneOntologyTer
+  rel: supportingInformation_GeneOntologyTerm
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1514,9 +1514,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1641,7 +1641,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ContactDetai
+  rel: supportingInformation_ContactDetail
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1650,9 +1650,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1675,7 +1675,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_MedicationRequestDispenseRequestInitialFi
+  rel: supportingInformation_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1684,15 +1684,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStudyLabe
+  rel: supportingInformation_ResearchStudyLabel
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1701,9 +1701,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1794,7 +1794,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_CitationCitedArtifactContributorshipSummar
+  rel: supportingInformation_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1803,9 +1803,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -1828,7 +1828,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ImagingStud
+  rel: supportingInformation_ImagingStudy
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -1837,9 +1837,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2066,7 +2066,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_SubstanceDefinitionMoiet
+  rel: supportingInformation_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2075,15 +2075,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Availabilit
+  rel: supportingInformation_Availability
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2092,9 +2092,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2117,7 +2117,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Quantit
+  rel: supportingInformation_Quantity
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2126,9 +2126,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2253,7 +2253,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_VirtualServiceDetai
+  rel: supportingInformation_VirtualServiceDetail
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2262,15 +2262,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_ResearchStud
+  rel: supportingInformation_ResearchStudy
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2279,9 +2279,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2559,7 +2559,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Met
+  rel: supportingInformation_Meta
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2568,9 +2568,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:
@@ -2627,7 +2627,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInformation_Pathw
+  rel: supportingInformation_Pathway
   targetHints:
     backref:
     - supportingInformation_medicationrequest
@@ -2636,9 +2636,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /supportingInformation/-/reference
   templateRequired:

--- a/schema/MedicationStatement.yaml
+++ b/schema/MedicationStatement.yaml
@@ -197,7 +197,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_CitationCitedArtifactContributorshipEntr
+  rel: derivedFrom_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -206,9 +206,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -248,7 +248,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_SampledDat
+  rel: derivedFrom_SampledData
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -257,9 +257,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -282,7 +282,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_FamilyMemberHistor
+  rel: derivedFrom_FamilyMemberHistory
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -291,9 +291,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -350,7 +350,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ObservationTriggeredB
+  rel: derivedFrom_ObservationTriggeredBy
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -359,9 +359,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -520,7 +520,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_SubstanceDefinitionPropert
+  rel: derivedFrom_SubstanceDefinitionProperty
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -529,9 +529,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -792,7 +792,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_SubstanceDefinitionSourceMateri
+  rel: derivedFrom_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -801,9 +801,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -843,7 +843,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ExtendedContactDetai
+  rel: derivedFrom_ExtendedContactDetail
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -852,9 +852,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1047,7 +1047,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ResearchStudyAssociatedPart
+  rel: derivedFrom_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1056,9 +1056,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1285,7 +1285,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_SubstanceDefinitionNameOffici
+  rel: derivedFrom_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1294,15 +1294,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_CitationSummar
+  rel: derivedFrom_CitationSummary
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1311,15 +1311,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_Mone
+  rel: derivedFrom_Money
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1328,9 +1328,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1370,7 +1370,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_CitationCitedArtifactPublicationFor
+  rel: derivedFrom_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1379,9 +1379,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1506,7 +1506,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_GeneOntologyTer
+  rel: derivedFrom_GeneOntologyTerm
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1515,9 +1515,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1642,7 +1642,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ContactDetai
+  rel: derivedFrom_ContactDetail
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1651,9 +1651,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1676,7 +1676,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_MedicationRequestDispenseRequestInitialFi
+  rel: derivedFrom_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1685,15 +1685,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ResearchStudyLabe
+  rel: derivedFrom_ResearchStudyLabel
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1702,9 +1702,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1795,7 +1795,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_CitationCitedArtifactContributorshipSummar
+  rel: derivedFrom_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1804,9 +1804,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -1829,7 +1829,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ImagingStud
+  rel: derivedFrom_ImagingStudy
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -1838,9 +1838,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -2067,7 +2067,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_SubstanceDefinitionMoiet
+  rel: derivedFrom_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2076,15 +2076,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_Availabilit
+  rel: derivedFrom_Availability
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2093,9 +2093,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -2118,7 +2118,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_Quantit
+  rel: derivedFrom_Quantity
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2127,9 +2127,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -2254,7 +2254,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_VirtualServiceDetai
+  rel: derivedFrom_VirtualServiceDetail
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2263,15 +2263,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_ResearchStud
+  rel: derivedFrom_ResearchStudy
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2280,9 +2280,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -2560,7 +2560,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_Met
+  rel: derivedFrom_Meta
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2569,9 +2569,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:
@@ -2628,7 +2628,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: derivedFrom_Pathw
+  rel: derivedFrom_Pathway
   targetHints:
     backref:
     - derivedFrom_medicationstatement
@@ -2637,9 +2637,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /derivedFrom/-/reference
   templateRequired:

--- a/schema/MedicationStatement.yaml
+++ b/schema/MedicationStatement.yaml
@@ -128,6 +128,2879 @@ links:
     id: /note/-/authorReference/reference
   templateRequired:
   - id
+- href: id
+  rel: derivedFrom_MedicationAdministration
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DocumentReference
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TaskPerformer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Timing
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SampledDat
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_FamilyMemberHistor
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_RelatedArtifact
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Observation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ObservationTriggeredB
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Phenotype
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_PatientLink
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TaskOutput
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Patient
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Annotation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Substance
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_UsageContext
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CodeableReference
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Allele
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ProteinStructure
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationRequest
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Period
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_EncounterParticipant
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ConditionParticipant
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CopyNumberAlteration
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ExtendedContactDetai
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Protein
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DataRequirementSort
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ImagingStudySeries
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_GenomicFeature
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifact
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationStatement
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Gene
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Task
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Range
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_PatientContact
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DataRequirement
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Condition
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Citation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SpecimenCollection
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Attachment
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationIngredient
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationSummar
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Mone
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Encounter
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TaskRestriction
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_RatioRange
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SomaticVariant
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TranscriptExpression
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MethylationProbe
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_GeneOntologyTer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationClassification
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Resource
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_GeneExpression
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DosageDoseAndRate
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ObservationReferenceRange
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ContactDetai
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Procedure
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyLabe
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyObjective
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ProcedurePerformer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Distance
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationStatusDate
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ImagingStud
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Methylation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Interaction
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SomaticCallset
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ObservationComponent
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Address
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Expression
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceIngredient
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_EncounterLocation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_EncounterDiagnosis
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Reference
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Transcript
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Availabilit
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Count
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Quantit
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_GeneSet
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Narrative
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SpecimenFeature
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DocumentReferenceContent
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_EncounterAdmission
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_VirtualServiceDetai
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStud
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_EncounterReason
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Signature
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Dosage
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_PatientCommunication
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Specimen
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SpecimenContainer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Extension
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_DrugResponse
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_HumanName
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TriggerDefinition
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Met
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_AlleleEffect
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Pathw
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Identifier
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TaskInput
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Medication
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_MedicationBatch
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ResearchSubject
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Publication
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CodeableConcept
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ContactPoint
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Exon
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Age
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinition
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ConditionStage
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Duration
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SpecimenProcessing
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Ratio
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_ParameterDefinition
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_Coding
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: derivedFrom_TimingRepeat
+  targetHints:
+    backref:
+    - derivedFrom_medicationstatement
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /derivedFrom/-/reference
+  templateRequired:
+  - id
 properties:
   _dateAsserted:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/Observation.yaml
+++ b/schema/Observation.yaml
@@ -284,7 +284,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactContributorshipEntr
+  rel: focus_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - focus_observation
@@ -293,9 +293,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -335,7 +335,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SampledDat
+  rel: focus_SampledData
   targetHints:
     backref:
     - focus_observation
@@ -344,9 +344,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -369,7 +369,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_FamilyMemberHistor
+  rel: focus_FamilyMemberHistory
   targetHints:
     backref:
     - focus_observation
@@ -378,9 +378,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -437,7 +437,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ObservationTriggeredB
+  rel: focus_ObservationTriggeredBy
   targetHints:
     backref:
     - focus_observation
@@ -446,9 +446,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -607,7 +607,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionPropert
+  rel: focus_SubstanceDefinitionProperty
   targetHints:
     backref:
     - focus_observation
@@ -616,9 +616,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -879,7 +879,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionSourceMateri
+  rel: focus_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - focus_observation
@@ -888,9 +888,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -930,7 +930,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ExtendedContactDetai
+  rel: focus_ExtendedContactDetail
   targetHints:
     backref:
     - focus_observation
@@ -939,9 +939,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1134,7 +1134,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStudyAssociatedPart
+  rel: focus_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - focus_observation
@@ -1143,9 +1143,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1372,7 +1372,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionNameOffici
+  rel: focus_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - focus_observation
@@ -1381,15 +1381,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationSummar
+  rel: focus_CitationSummary
   targetHints:
     backref:
     - focus_observation
@@ -1398,15 +1398,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_Mone
+  rel: focus_Money
   targetHints:
     backref:
     - focus_observation
@@ -1415,9 +1415,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1457,7 +1457,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactPublicationFor
+  rel: focus_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - focus_observation
@@ -1466,9 +1466,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1593,7 +1593,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_GeneOntologyTer
+  rel: focus_GeneOntologyTerm
   targetHints:
     backref:
     - focus_observation
@@ -1602,9 +1602,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1729,7 +1729,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ContactDetai
+  rel: focus_ContactDetail
   targetHints:
     backref:
     - focus_observation
@@ -1738,9 +1738,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1763,7 +1763,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_MedicationRequestDispenseRequestInitialFi
+  rel: focus_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - focus_observation
@@ -1772,15 +1772,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStudyLabe
+  rel: focus_ResearchStudyLabel
   targetHints:
     backref:
     - focus_observation
@@ -1789,9 +1789,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1882,7 +1882,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactContributorshipSummar
+  rel: focus_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - focus_observation
@@ -1891,9 +1891,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -1916,7 +1916,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ImagingStud
+  rel: focus_ImagingStudy
   targetHints:
     backref:
     - focus_observation
@@ -1925,9 +1925,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -2154,7 +2154,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionMoiet
+  rel: focus_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - focus_observation
@@ -2163,15 +2163,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_Availabilit
+  rel: focus_Availability
   targetHints:
     backref:
     - focus_observation
@@ -2180,9 +2180,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -2205,7 +2205,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Quantit
+  rel: focus_Quantity
   targetHints:
     backref:
     - focus_observation
@@ -2214,9 +2214,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -2341,7 +2341,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_VirtualServiceDetai
+  rel: focus_VirtualServiceDetail
   targetHints:
     backref:
     - focus_observation
@@ -2350,15 +2350,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStud
+  rel: focus_ResearchStudy
   targetHints:
     backref:
     - focus_observation
@@ -2367,9 +2367,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -2647,7 +2647,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Met
+  rel: focus_Meta
   targetHints:
     backref:
     - focus_observation
@@ -2656,9 +2656,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:
@@ -2715,7 +2715,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Pathw
+  rel: focus_Pathway
   targetHints:
     backref:
     - focus_observation
@@ -2724,9 +2724,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /focus/-/reference
   templateRequired:

--- a/schema/Observation.yaml
+++ b/schema/Observation.yaml
@@ -215,6 +215,2879 @@ links:
     id: /triggeredBy/-/observation/reference
   templateRequired:
   - id
+- href: id
+  rel: focus_MedicationAdministration
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReference
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskPerformer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Timing
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SampledDat
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistor
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_RelatedArtifact
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Observation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationTriggeredB
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Phenotype
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientLink
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskOutput
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Patient
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Annotation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Substance
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_UsageContext
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CodeableReference
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Allele
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProteinStructure
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequest
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Period
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterParticipant
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ConditionParticipant
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CopyNumberAlteration
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ExtendedContactDetai
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Protein
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementSort
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeries
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GenomicFeature
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifact
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationStatement
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Gene
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Task
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Range
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientContact
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirement
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Condition
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Citation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenCollection
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Attachment
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationIngredient
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationSummar
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Mone
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Encounter
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskRestriction
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_RatioRange
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SomaticVariant
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TranscriptExpression
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MethylationProbe
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneOntologyTer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationClassification
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Resource
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneExpression
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DosageDoseAndRate
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationReferenceRange
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ContactDetai
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Procedure
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyLabe
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyObjective
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProcedurePerformer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Distance
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationStatusDate
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStud
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Methylation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Interaction
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SomaticCallset
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationComponent
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Address
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Expression
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceIngredient
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterLocation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterDiagnosis
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Reference
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Transcript
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Availabilit
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Count
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Quantit
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneSet
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Narrative
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenFeature
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceContent
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterAdmission
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_VirtualServiceDetai
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStud
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterReason
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Signature
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Dosage
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientCommunication
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Specimen
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenContainer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Extension
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DrugResponse
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_HumanName
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TriggerDefinition
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Met
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AlleleEffect
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Pathw
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Identifier
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskInput
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Medication
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationBatch
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchSubject
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Publication
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CodeableConcept
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ContactPoint
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Exon
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Age
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinition
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ConditionStage
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Duration
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenProcessing
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Ratio
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ParameterDefinition
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Coding
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TimingRepeat
+  targetHints:
+    backref:
+    - focus_observation
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /focus/-/reference
+  templateRequired:
+  - id
 properties:
   _effectiveDateTime:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/Procedure.yaml
+++ b/schema/Procedure.yaml
@@ -273,7 +273,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_CitationCitedArtifactContributorshipEntr
+  rel: supportingInfo_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -282,9 +282,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -324,7 +324,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_SampledDat
+  rel: supportingInfo_SampledData
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -333,9 +333,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -358,7 +358,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_FamilyMemberHistor
+  rel: supportingInfo_FamilyMemberHistory
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -367,9 +367,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -426,7 +426,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ObservationTriggeredB
+  rel: supportingInfo_ObservationTriggeredBy
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -435,9 +435,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -596,7 +596,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_SubstanceDefinitionPropert
+  rel: supportingInfo_SubstanceDefinitionProperty
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -605,9 +605,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -868,7 +868,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_SubstanceDefinitionSourceMateri
+  rel: supportingInfo_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -877,9 +877,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -919,7 +919,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ExtendedContactDetai
+  rel: supportingInfo_ExtendedContactDetail
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -928,9 +928,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1123,7 +1123,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ResearchStudyAssociatedPart
+  rel: supportingInfo_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1132,9 +1132,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1361,7 +1361,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_SubstanceDefinitionNameOffici
+  rel: supportingInfo_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1370,15 +1370,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_CitationSummar
+  rel: supportingInfo_CitationSummary
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1387,15 +1387,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_Mone
+  rel: supportingInfo_Money
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1404,9 +1404,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1446,7 +1446,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_CitationCitedArtifactPublicationFor
+  rel: supportingInfo_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1455,9 +1455,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1582,7 +1582,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_GeneOntologyTer
+  rel: supportingInfo_GeneOntologyTerm
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1591,9 +1591,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1718,7 +1718,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ContactDetai
+  rel: supportingInfo_ContactDetail
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1727,9 +1727,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1752,7 +1752,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_MedicationRequestDispenseRequestInitialFi
+  rel: supportingInfo_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1761,15 +1761,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ResearchStudyLabe
+  rel: supportingInfo_ResearchStudyLabel
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1778,9 +1778,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1871,7 +1871,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_CitationCitedArtifactContributorshipSummar
+  rel: supportingInfo_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1880,9 +1880,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -1905,7 +1905,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ImagingStud
+  rel: supportingInfo_ImagingStudy
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -1914,9 +1914,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -2143,7 +2143,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_SubstanceDefinitionMoiet
+  rel: supportingInfo_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2152,15 +2152,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_Availabilit
+  rel: supportingInfo_Availability
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2169,9 +2169,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -2194,7 +2194,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_Quantit
+  rel: supportingInfo_Quantity
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2203,9 +2203,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -2330,7 +2330,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_VirtualServiceDetai
+  rel: supportingInfo_VirtualServiceDetail
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2339,15 +2339,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_ResearchStud
+  rel: supportingInfo_ResearchStudy
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2356,9 +2356,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -2636,7 +2636,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_Met
+  rel: supportingInfo_Meta
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2645,9 +2645,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:
@@ -2704,7 +2704,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: supportingInfo_Pathw
+  rel: supportingInfo_Pathway
   targetHints:
     backref:
     - supportingInfo_procedure
@@ -2713,9 +2713,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /supportingInfo/-/reference
   templateRequired:

--- a/schema/Procedure.yaml
+++ b/schema/Procedure.yaml
@@ -204,6 +204,2879 @@ links:
     id: /performer/-/actor/reference
   templateRequired:
   - id
+- href: id
+  rel: supportingInfo_MedicationAdministration
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DocumentReference
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TaskPerformer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Timing
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SampledDat
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_FamilyMemberHistor
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_RelatedArtifact
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Observation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ObservationTriggeredB
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Phenotype
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_PatientLink
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TaskOutput
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Patient
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Annotation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Substance
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_UsageContext
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CodeableReference
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Allele
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ProteinStructure
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationRequest
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Period
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_EncounterParticipant
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ConditionParticipant
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CopyNumberAlteration
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ExtendedContactDetai
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Protein
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DataRequirementSort
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ImagingStudySeries
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_GenomicFeature
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifact
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationStatement
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Gene
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Task
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Range
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_PatientContact
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DataRequirement
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Condition
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Citation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SpecimenCollection
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Attachment
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationIngredient
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationSummar
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Mone
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Encounter
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TaskRestriction
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_RatioRange
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SomaticVariant
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TranscriptExpression
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MethylationProbe
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_GeneOntologyTer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationClassification
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Resource
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_GeneExpression
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DosageDoseAndRate
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ObservationReferenceRange
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ContactDetai
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Procedure
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyLabe
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyObjective
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ProcedurePerformer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Distance
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationStatusDate
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ImagingStud
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Methylation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Interaction
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SomaticCallset
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ObservationComponent
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Address
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Expression
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceIngredient
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_EncounterLocation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_EncounterDiagnosis
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Reference
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Transcript
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Availabilit
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Count
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Quantit
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_GeneSet
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Narrative
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SpecimenFeature
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DocumentReferenceContent
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_EncounterAdmission
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_VirtualServiceDetai
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStud
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_EncounterReason
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Signature
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Dosage
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_PatientCommunication
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Specimen
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SpecimenContainer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Extension
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_DrugResponse
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_HumanName
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TriggerDefinition
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Met
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_AlleleEffect
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Pathw
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Identifier
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TaskInput
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Medication
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_MedicationBatch
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ResearchSubject
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Publication
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CodeableConcept
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ContactPoint
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Exon
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Age
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinition
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ConditionStage
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Duration
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SpecimenProcessing
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Ratio
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_ParameterDefinition
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_Coding
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: supportingInfo_TimingRepeat
+  targetHints:
+    backref:
+    - supportingInfo_procedure
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /supportingInfo/-/reference
+  templateRequired:
+  - id
 properties:
   _implicitRules:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/RelatedArtifact.yaml
+++ b/schema/RelatedArtifact.yaml
@@ -18,6 +18,2879 @@ links:
     id: /resourceReference/reference
   templateRequired:
   - id
+- href: id
+  rel: resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Timing
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SampledDat
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Observation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Phenotype
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_PatientLink
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Patient
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Annotation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Substance
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_UsageContext
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Allele
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Period
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Protein
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Gene
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Task
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Range
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_PatientContact
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Condition
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Citation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Attachment
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Mone
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Encounter
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_RatioRange
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Resource
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Procedure
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Distance
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Methylation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Interaction
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Address
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Expression
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Reference
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Transcript
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Availabilit
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Count
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Quantit
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_GeneSet
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Narrative
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Signature
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Dosage
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Specimen
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Extension
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_HumanName
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Met
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Pathw
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Identifier
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TaskInput
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Medication
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Publication
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Exon
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Age
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Duration
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Ratio
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_Coding
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - resourceReference_relatedartifact
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /resourceReference/reference
+  templateRequired:
+  - id
 properties:
   _citation:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/RelatedArtifact.yaml
+++ b/schema/RelatedArtifact.yaml
@@ -87,7 +87,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -96,9 +96,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -138,7 +138,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_SampledDat
+  rel: resourceReference_SampledData
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -147,9 +147,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -172,7 +172,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_FamilyMemberHistor
+  rel: resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -181,9 +181,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -240,7 +240,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ObservationTriggeredB
+  rel: resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -249,9 +249,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -410,7 +410,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_SubstanceDefinitionPropert
+  rel: resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -419,9 +419,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -682,7 +682,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_SubstanceDefinitionSourceMateri
+  rel: resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -691,9 +691,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -733,7 +733,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ExtendedContactDetai
+  rel: resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -742,9 +742,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -937,7 +937,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ResearchStudyAssociatedPart
+  rel: resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -946,9 +946,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1175,7 +1175,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_SubstanceDefinitionNameOffici
+  rel: resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1184,15 +1184,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_CitationSummar
+  rel: resourceReference_CitationSummary
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1201,15 +1201,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_Mone
+  rel: resourceReference_Money
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1218,9 +1218,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1260,7 +1260,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_CitationCitedArtifactPublicationFor
+  rel: resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1269,9 +1269,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1396,7 +1396,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_GeneOntologyTer
+  rel: resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1405,9 +1405,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1532,7 +1532,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ContactDetai
+  rel: resourceReference_ContactDetail
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1541,9 +1541,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1566,7 +1566,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1575,15 +1575,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ResearchStudyLabe
+  rel: resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1592,9 +1592,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1685,7 +1685,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1694,9 +1694,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1719,7 +1719,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ImagingStud
+  rel: resourceReference_ImagingStudy
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1728,9 +1728,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -1957,7 +1957,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_SubstanceDefinitionMoiet
+  rel: resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1966,15 +1966,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_Availabilit
+  rel: resourceReference_Availability
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -1983,9 +1983,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -2008,7 +2008,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_Quantit
+  rel: resourceReference_Quantity
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -2017,9 +2017,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -2144,7 +2144,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_VirtualServiceDetai
+  rel: resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -2153,15 +2153,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_ResearchStud
+  rel: resourceReference_ResearchStudy
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -2170,9 +2170,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -2450,7 +2450,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_Met
+  rel: resourceReference_Meta
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -2459,9 +2459,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:
@@ -2518,7 +2518,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: resourceReference_Pathw
+  rel: resourceReference_Pathway
   targetHints:
     backref:
     - resourceReference_relatedartifact
@@ -2527,9 +2527,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /resourceReference/reference
   templateRequired:

--- a/schema/ResearchStudy.yaml
+++ b/schema/ResearchStudy.yaml
@@ -69,6 +69,2879 @@ links:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Timing
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SampledDat
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Observation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Phenotype
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientLink
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Patient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Annotation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Substance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_UsageContext
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Allele
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Period
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Protein
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Gene
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Task
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Range
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientContact
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Condition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Citation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Attachment
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Mone
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Encounter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_RatioRange
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Resource
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Procedure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Distance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Methylation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Interaction
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Address
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Expression
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Reference
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Transcript
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Availabilit
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Count
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Quantit
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_GeneSet
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Narrative
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Signature
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Dosage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Specimen
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Extension
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_HumanName
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Met
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Pathw
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Identifier
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TaskInput
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Medication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Publication
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Exon
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Age
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Duration
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Ratio
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_Coding
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: relatedArtifact_resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - relatedArtifact_resourceReference_researchstudy
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /relatedArtifact/-/resourceReference/reference
+  templateRequired:
+  - id
 properties:
   _date:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/ResearchStudy.yaml
+++ b/schema/ResearchStudy.yaml
@@ -138,7 +138,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -147,9 +147,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -189,7 +189,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SampledDat
+  rel: relatedArtifact_resourceReference_SampledData
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -198,9 +198,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -223,7 +223,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_FamilyMemberHistor
+  rel: relatedArtifact_resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -232,9 +232,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -291,7 +291,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ObservationTriggeredB
+  rel: relatedArtifact_resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -300,9 +300,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -461,7 +461,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionPropert
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -470,9 +470,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -733,7 +733,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -742,9 +742,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -784,7 +784,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ExtendedContactDetai
+  rel: relatedArtifact_resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -793,9 +793,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -988,7 +988,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  rel: relatedArtifact_resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -997,9 +997,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1226,7 +1226,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1235,15 +1235,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationSummar
+  rel: relatedArtifact_resourceReference_CitationSummary
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1252,15 +1252,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Mone
+  rel: relatedArtifact_resourceReference_Money
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1269,9 +1269,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1311,7 +1311,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1320,9 +1320,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1447,7 +1447,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_GeneOntologyTer
+  rel: relatedArtifact_resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1456,9 +1456,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1583,7 +1583,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ContactDetai
+  rel: relatedArtifact_resourceReference_ContactDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1592,9 +1592,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1617,7 +1617,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: relatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1626,15 +1626,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStudyLabe
+  rel: relatedArtifact_resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1643,9 +1643,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1736,7 +1736,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: relatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1745,9 +1745,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -1770,7 +1770,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ImagingStud
+  rel: relatedArtifact_resourceReference_ImagingStudy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -1779,9 +1779,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2008,7 +2008,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  rel: relatedArtifact_resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2017,15 +2017,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Availabilit
+  rel: relatedArtifact_resourceReference_Availability
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2034,9 +2034,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2059,7 +2059,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Quantit
+  rel: relatedArtifact_resourceReference_Quantity
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2068,9 +2068,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2195,7 +2195,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_VirtualServiceDetai
+  rel: relatedArtifact_resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2204,15 +2204,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_ResearchStud
+  rel: relatedArtifact_resourceReference_ResearchStudy
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2221,9 +2221,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2501,7 +2501,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Met
+  rel: relatedArtifact_resourceReference_Meta
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2510,9 +2510,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:
@@ -2569,7 +2569,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: relatedArtifact_resourceReference_Pathw
+  rel: relatedArtifact_resourceReference_Pathway
   targetHints:
     backref:
     - relatedArtifact_resourceReference_researchstudy
@@ -2578,9 +2578,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /relatedArtifact/-/resourceReference/reference
   templateRequired:

--- a/schema/Task.yaml
+++ b/schema/Task.yaml
@@ -185,6 +185,8625 @@ links:
     id: /documents/-/id
   templateRequired:
   - id
+- href: id
+  rel: basedOn_MedicationAdministration
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DocumentReference
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TaskPerformer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Timing
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SampledDat
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_FamilyMemberHistor
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_RelatedArtifact
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Observation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ObservationTriggeredB
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Phenotype
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_PatientLink
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TaskOutput
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Patient
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Annotation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Substance
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_UsageContext
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CodeableReference
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Allele
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ProteinStructure
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationRequest
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Period
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_EncounterParticipant
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ConditionParticipant
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CopyNumberAlteration
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ExtendedContactDetai
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Protein
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DataRequirementSort
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ImagingStudySeries
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_GenomicFeature
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifact
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationStatement
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Gene
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Task
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Range
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_PatientContact
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DataRequirement
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Condition
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Citation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SpecimenCollection
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Attachment
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationIngredient
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationSummar
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Mone
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Encounter
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TaskRestriction
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_RatioRange
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SomaticVariant
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TranscriptExpression
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MethylationProbe
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_GeneOntologyTer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationClassification
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Resource
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_GeneExpression
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DosageDoseAndRate
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ObservationReferenceRange
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ContactDetai
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Procedure
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyLabe
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyObjective
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ProcedurePerformer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Distance
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationStatusDate
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ImagingStud
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Methylation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Interaction
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SomaticCallset
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ObservationComponent
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Address
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Expression
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceIngredient
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_EncounterLocation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_EncounterDiagnosis
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Reference
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Transcript
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Availabilit
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Count
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Quantit
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_GeneSet
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Narrative
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SpecimenFeature
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DocumentReferenceContent
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_EncounterAdmission
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_VirtualServiceDetai
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStud
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_EncounterReason
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Signature
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Dosage
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_PatientCommunication
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Specimen
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SpecimenContainer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Extension
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_DrugResponse
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_HumanName
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TriggerDefinition
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Met
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_AlleleEffect
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Pathw
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Identifier
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TaskInput
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Medication
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_MedicationBatch
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ResearchSubject
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Publication
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CodeableConcept
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ContactPoint
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Exon
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Age
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinition
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ConditionStage
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Duration
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SpecimenProcessing
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Ratio
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_ParameterDefinition
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_Coding
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: basedOn_TimingRepeat
+  targetHints:
+    backref:
+    - basedOn_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /basedOn/-/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationAdministration
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReference
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskPerformer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Timing
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SampledDat
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistor
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_RelatedArtifact
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Observation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationTriggeredB
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Phenotype
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientLink
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskOutput
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Patient
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Annotation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Substance
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_UsageContext
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CodeableReference
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Allele
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProteinStructure
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequest
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Period
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterParticipant
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ConditionParticipant
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CopyNumberAlteration
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ExtendedContactDetai
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Protein
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementSort
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeries
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GenomicFeature
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifact
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationStatement
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Gene
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Task
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Range
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientContact
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirement
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Condition
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Citation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenCollection
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Attachment
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationIngredient
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationSummar
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Mone
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Encounter
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskRestriction
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_RatioRange
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SomaticVariant
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TranscriptExpression
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MethylationProbe
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneOntologyTer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationClassification
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Resource
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneExpression
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DosageDoseAndRate
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationReferenceRange
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ContactDetai
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Procedure
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyLabe
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyObjective
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProcedurePerformer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Distance
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationStatusDate
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ImagingStud
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Methylation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Interaction
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SomaticCallset
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ObservationComponent
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Address
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Expression
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceIngredient
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterLocation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterDiagnosis
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Reference
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Transcript
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Availabilit
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Count
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Quantit
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_GeneSet
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Narrative
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenFeature
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DocumentReferenceContent
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterAdmission
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_VirtualServiceDetai
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStud
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_EncounterReason
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Signature
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Dosage
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_PatientCommunication
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Specimen
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenContainer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Extension
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_DrugResponse
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_HumanName
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TriggerDefinition
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Met
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_AlleleEffect
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Pathw
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Identifier
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TaskInput
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Medication
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_MedicationBatch
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ResearchSubject
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Publication
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CodeableConcept
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ContactPoint
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Exon
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Age
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinition
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ConditionStage
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Duration
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SpecimenProcessing
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Ratio
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_ParameterDefinition
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_Coding
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: focus_TimingRepeat
+  targetHints:
+    backref:
+    - focus_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /focus/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationAdministration
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DocumentReference
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TaskPerformer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Timing
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SampledDat
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_FamilyMemberHistor
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_RelatedArtifact
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Observation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ObservationTriggeredB
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Phenotype
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_PatientLink
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TaskOutput
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Patient
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Annotation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Substance
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_UsageContext
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CodeableReference
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Allele
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ProteinStructure
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationRequest
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Period
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_EncounterParticipant
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ConditionParticipant
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CopyNumberAlteration
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ExtendedContactDetai
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Protein
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DataRequirementSort
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ImagingStudySeries
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_GenomicFeature
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifact
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationStatement
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Gene
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Task
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Range
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_PatientContact
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DataRequirement
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Condition
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Citation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SpecimenCollection
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Attachment
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationIngredient
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationSummar
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Mone
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Encounter
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TaskRestriction
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_RatioRange
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SomaticVariant
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TranscriptExpression
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MethylationProbe
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_GeneOntologyTer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationClassification
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Resource
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_GeneExpression
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DosageDoseAndRate
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ObservationReferenceRange
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ContactDetai
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Procedure
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyLabe
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyObjective
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ProcedurePerformer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Distance
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationStatusDate
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ImagingStud
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Methylation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Interaction
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SomaticCallset
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ObservationComponent
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Address
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Expression
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceIngredient
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_EncounterLocation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_EncounterDiagnosis
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Reference
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Transcript
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Availabilit
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Count
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Quantit
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_GeneSet
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Narrative
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SpecimenFeature
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DocumentReferenceContent
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_EncounterAdmission
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_VirtualServiceDetai
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStud
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_EncounterReason
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Signature
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Dosage
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_PatientCommunication
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Specimen
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SpecimenContainer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Extension
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_DrugResponse
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_HumanName
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TriggerDefinition
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Met
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_AlleleEffect
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Pathw
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Identifier
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TaskInput
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Medication
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_MedicationBatch
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ResearchSubject
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Publication
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CodeableConcept
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ContactPoint
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Exon
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Age
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinition
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ConditionStage
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Duration
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SpecimenProcessing
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Ratio
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_ParameterDefinition
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_Coding
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
+- href: id
+  rel: for_fhir_TimingRepeat
+  targetHints:
+    backref:
+    - for_fhir_task
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /for_fhir/reference
+  templateRequired:
+  - id
 properties:
   _authoredOn:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/Task.yaml
+++ b/schema/Task.yaml
@@ -254,7 +254,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_CitationCitedArtifactContributorshipEntr
+  rel: basedOn_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - basedOn_task
@@ -263,9 +263,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -305,7 +305,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_SampledDat
+  rel: basedOn_SampledData
   targetHints:
     backref:
     - basedOn_task
@@ -314,9 +314,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -339,7 +339,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_FamilyMemberHistor
+  rel: basedOn_FamilyMemberHistory
   targetHints:
     backref:
     - basedOn_task
@@ -348,9 +348,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -407,7 +407,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ObservationTriggeredB
+  rel: basedOn_ObservationTriggeredBy
   targetHints:
     backref:
     - basedOn_task
@@ -416,9 +416,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -577,7 +577,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_SubstanceDefinitionPropert
+  rel: basedOn_SubstanceDefinitionProperty
   targetHints:
     backref:
     - basedOn_task
@@ -586,9 +586,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -849,7 +849,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_SubstanceDefinitionSourceMateri
+  rel: basedOn_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - basedOn_task
@@ -858,9 +858,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -900,7 +900,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ExtendedContactDetai
+  rel: basedOn_ExtendedContactDetail
   targetHints:
     backref:
     - basedOn_task
@@ -909,9 +909,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1104,7 +1104,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ResearchStudyAssociatedPart
+  rel: basedOn_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - basedOn_task
@@ -1113,9 +1113,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1342,7 +1342,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_SubstanceDefinitionNameOffici
+  rel: basedOn_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - basedOn_task
@@ -1351,15 +1351,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
   - id
 - href: id
-  rel: basedOn_CitationSummar
+  rel: basedOn_CitationSummary
   targetHints:
     backref:
     - basedOn_task
@@ -1368,15 +1368,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
   - id
 - href: id
-  rel: basedOn_Mone
+  rel: basedOn_Money
   targetHints:
     backref:
     - basedOn_task
@@ -1385,9 +1385,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1427,7 +1427,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_CitationCitedArtifactPublicationFor
+  rel: basedOn_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - basedOn_task
@@ -1436,9 +1436,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1563,7 +1563,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_GeneOntologyTer
+  rel: basedOn_GeneOntologyTerm
   targetHints:
     backref:
     - basedOn_task
@@ -1572,9 +1572,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1699,7 +1699,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ContactDetai
+  rel: basedOn_ContactDetail
   targetHints:
     backref:
     - basedOn_task
@@ -1708,9 +1708,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1733,7 +1733,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_MedicationRequestDispenseRequestInitialFi
+  rel: basedOn_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - basedOn_task
@@ -1742,15 +1742,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ResearchStudyLabe
+  rel: basedOn_ResearchStudyLabel
   targetHints:
     backref:
     - basedOn_task
@@ -1759,9 +1759,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1852,7 +1852,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_CitationCitedArtifactContributorshipSummar
+  rel: basedOn_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - basedOn_task
@@ -1861,9 +1861,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -1886,7 +1886,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ImagingStud
+  rel: basedOn_ImagingStudy
   targetHints:
     backref:
     - basedOn_task
@@ -1895,9 +1895,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -2124,7 +2124,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_SubstanceDefinitionMoiet
+  rel: basedOn_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - basedOn_task
@@ -2133,15 +2133,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
   - id
 - href: id
-  rel: basedOn_Availabilit
+  rel: basedOn_Availability
   targetHints:
     backref:
     - basedOn_task
@@ -2150,9 +2150,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -2175,7 +2175,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_Quantit
+  rel: basedOn_Quantity
   targetHints:
     backref:
     - basedOn_task
@@ -2184,9 +2184,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -2311,7 +2311,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_VirtualServiceDetai
+  rel: basedOn_VirtualServiceDetail
   targetHints:
     backref:
     - basedOn_task
@@ -2320,15 +2320,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
   - id
 - href: id
-  rel: basedOn_ResearchStud
+  rel: basedOn_ResearchStudy
   targetHints:
     backref:
     - basedOn_task
@@ -2337,9 +2337,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -2617,7 +2617,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_Met
+  rel: basedOn_Meta
   targetHints:
     backref:
     - basedOn_task
@@ -2626,9 +2626,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -2685,7 +2685,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: basedOn_Pathw
+  rel: basedOn_Pathway
   targetHints:
     backref:
     - basedOn_task
@@ -2694,9 +2694,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /basedOn/-/reference
   templateRequired:
@@ -3127,7 +3127,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactContributorshipEntr
+  rel: focus_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - focus_task
@@ -3136,9 +3136,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3178,7 +3178,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SampledDat
+  rel: focus_SampledData
   targetHints:
     backref:
     - focus_task
@@ -3187,9 +3187,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3212,7 +3212,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_FamilyMemberHistor
+  rel: focus_FamilyMemberHistory
   targetHints:
     backref:
     - focus_task
@@ -3221,9 +3221,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3280,7 +3280,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ObservationTriggeredB
+  rel: focus_ObservationTriggeredBy
   targetHints:
     backref:
     - focus_task
@@ -3289,9 +3289,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3450,7 +3450,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionPropert
+  rel: focus_SubstanceDefinitionProperty
   targetHints:
     backref:
     - focus_task
@@ -3459,9 +3459,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3722,7 +3722,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionSourceMateri
+  rel: focus_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - focus_task
@@ -3731,9 +3731,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3773,7 +3773,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ExtendedContactDetai
+  rel: focus_ExtendedContactDetail
   targetHints:
     backref:
     - focus_task
@@ -3782,9 +3782,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -3977,7 +3977,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStudyAssociatedPart
+  rel: focus_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - focus_task
@@ -3986,9 +3986,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4215,7 +4215,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionNameOffici
+  rel: focus_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - focus_task
@@ -4224,15 +4224,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationSummar
+  rel: focus_CitationSummary
   targetHints:
     backref:
     - focus_task
@@ -4241,15 +4241,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_Mone
+  rel: focus_Money
   targetHints:
     backref:
     - focus_task
@@ -4258,9 +4258,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4300,7 +4300,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactPublicationFor
+  rel: focus_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - focus_task
@@ -4309,9 +4309,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4436,7 +4436,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_GeneOntologyTer
+  rel: focus_GeneOntologyTerm
   targetHints:
     backref:
     - focus_task
@@ -4445,9 +4445,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4572,7 +4572,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ContactDetai
+  rel: focus_ContactDetail
   targetHints:
     backref:
     - focus_task
@@ -4581,9 +4581,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4606,7 +4606,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_MedicationRequestDispenseRequestInitialFi
+  rel: focus_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - focus_task
@@ -4615,15 +4615,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStudyLabe
+  rel: focus_ResearchStudyLabel
   targetHints:
     backref:
     - focus_task
@@ -4632,9 +4632,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4725,7 +4725,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_CitationCitedArtifactContributorshipSummar
+  rel: focus_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - focus_task
@@ -4734,9 +4734,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4759,7 +4759,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_ImagingStud
+  rel: focus_ImagingStudy
   targetHints:
     backref:
     - focus_task
@@ -4768,9 +4768,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -4997,7 +4997,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_SubstanceDefinitionMoiet
+  rel: focus_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - focus_task
@@ -5006,15 +5006,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_Availabilit
+  rel: focus_Availability
   targetHints:
     backref:
     - focus_task
@@ -5023,9 +5023,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -5048,7 +5048,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Quantit
+  rel: focus_Quantity
   targetHints:
     backref:
     - focus_task
@@ -5057,9 +5057,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -5184,7 +5184,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_VirtualServiceDetai
+  rel: focus_VirtualServiceDetail
   targetHints:
     backref:
     - focus_task
@@ -5193,15 +5193,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
   - id
 - href: id
-  rel: focus_ResearchStud
+  rel: focus_ResearchStudy
   targetHints:
     backref:
     - focus_task
@@ -5210,9 +5210,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -5490,7 +5490,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Met
+  rel: focus_Meta
   targetHints:
     backref:
     - focus_task
@@ -5499,9 +5499,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -5558,7 +5558,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: focus_Pathw
+  rel: focus_Pathway
   targetHints:
     backref:
     - focus_task
@@ -5567,9 +5567,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /focus/reference
   templateRequired:
@@ -6000,7 +6000,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_CitationCitedArtifactContributorshipEntr
+  rel: for_fhir_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - for_fhir_task
@@ -6009,9 +6009,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6051,7 +6051,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_SampledDat
+  rel: for_fhir_SampledData
   targetHints:
     backref:
     - for_fhir_task
@@ -6060,9 +6060,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6085,7 +6085,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_FamilyMemberHistor
+  rel: for_fhir_FamilyMemberHistory
   targetHints:
     backref:
     - for_fhir_task
@@ -6094,9 +6094,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6153,7 +6153,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ObservationTriggeredB
+  rel: for_fhir_ObservationTriggeredBy
   targetHints:
     backref:
     - for_fhir_task
@@ -6162,9 +6162,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6323,7 +6323,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_SubstanceDefinitionPropert
+  rel: for_fhir_SubstanceDefinitionProperty
   targetHints:
     backref:
     - for_fhir_task
@@ -6332,9 +6332,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6595,7 +6595,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_SubstanceDefinitionSourceMateri
+  rel: for_fhir_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - for_fhir_task
@@ -6604,9 +6604,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6646,7 +6646,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ExtendedContactDetai
+  rel: for_fhir_ExtendedContactDetail
   targetHints:
     backref:
     - for_fhir_task
@@ -6655,9 +6655,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -6850,7 +6850,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ResearchStudyAssociatedPart
+  rel: for_fhir_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - for_fhir_task
@@ -6859,9 +6859,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7088,7 +7088,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_SubstanceDefinitionNameOffici
+  rel: for_fhir_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - for_fhir_task
@@ -7097,15 +7097,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_CitationSummar
+  rel: for_fhir_CitationSummary
   targetHints:
     backref:
     - for_fhir_task
@@ -7114,15 +7114,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_Mone
+  rel: for_fhir_Money
   targetHints:
     backref:
     - for_fhir_task
@@ -7131,9 +7131,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7173,7 +7173,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_CitationCitedArtifactPublicationFor
+  rel: for_fhir_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - for_fhir_task
@@ -7182,9 +7182,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7309,7 +7309,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_GeneOntologyTer
+  rel: for_fhir_GeneOntologyTerm
   targetHints:
     backref:
     - for_fhir_task
@@ -7318,9 +7318,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7445,7 +7445,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ContactDetai
+  rel: for_fhir_ContactDetail
   targetHints:
     backref:
     - for_fhir_task
@@ -7454,9 +7454,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7479,7 +7479,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_MedicationRequestDispenseRequestInitialFi
+  rel: for_fhir_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - for_fhir_task
@@ -7488,15 +7488,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ResearchStudyLabe
+  rel: for_fhir_ResearchStudyLabel
   targetHints:
     backref:
     - for_fhir_task
@@ -7505,9 +7505,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7598,7 +7598,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_CitationCitedArtifactContributorshipSummar
+  rel: for_fhir_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - for_fhir_task
@@ -7607,9 +7607,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7632,7 +7632,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ImagingStud
+  rel: for_fhir_ImagingStudy
   targetHints:
     backref:
     - for_fhir_task
@@ -7641,9 +7641,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7870,7 +7870,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_SubstanceDefinitionMoiet
+  rel: for_fhir_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - for_fhir_task
@@ -7879,15 +7879,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_Availabilit
+  rel: for_fhir_Availability
   targetHints:
     backref:
     - for_fhir_task
@@ -7896,9 +7896,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -7921,7 +7921,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_Quantit
+  rel: for_fhir_Quantity
   targetHints:
     backref:
     - for_fhir_task
@@ -7930,9 +7930,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -8057,7 +8057,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_VirtualServiceDetai
+  rel: for_fhir_VirtualServiceDetail
   targetHints:
     backref:
     - for_fhir_task
@@ -8066,15 +8066,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_ResearchStud
+  rel: for_fhir_ResearchStudy
   targetHints:
     backref:
     - for_fhir_task
@@ -8083,9 +8083,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -8363,7 +8363,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_Met
+  rel: for_fhir_Meta
   targetHints:
     backref:
     - for_fhir_task
@@ -8372,9 +8372,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:
@@ -8431,7 +8431,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: for_fhir_Pathw
+  rel: for_fhir_Pathway
   targetHints:
     backref:
     - for_fhir_task
@@ -8440,9 +8440,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /for_fhir/reference
   templateRequired:

--- a/schema/TaskInput.yaml
+++ b/schema/TaskInput.yaml
@@ -152,7 +152,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -161,9 +161,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -203,7 +203,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SampledDat
+  rel: valueRelatedArtifact_resourceReference_SampledData
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -212,9 +212,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -237,7 +237,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -246,9 +246,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -305,7 +305,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -314,9 +314,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -475,7 +475,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -484,9 +484,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -747,7 +747,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -756,9 +756,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -798,7 +798,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -807,9 +807,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1002,7 +1002,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1011,9 +1011,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1240,7 +1240,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1249,15 +1249,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  rel: valueRelatedArtifact_resourceReference_CitationSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1266,15 +1266,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Mone
+  rel: valueRelatedArtifact_resourceReference_Money
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1283,9 +1283,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1325,7 +1325,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1334,9 +1334,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1461,7 +1461,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1470,9 +1470,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1597,7 +1597,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  rel: valueRelatedArtifact_resourceReference_ContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1606,9 +1606,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1631,7 +1631,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1640,15 +1640,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1657,9 +1657,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1750,7 +1750,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1759,9 +1759,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1784,7 +1784,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  rel: valueRelatedArtifact_resourceReference_ImagingStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -1793,9 +1793,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2022,7 +2022,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2031,15 +2031,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Availabilit
+  rel: valueRelatedArtifact_resourceReference_Availability
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2048,9 +2048,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2073,7 +2073,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Quantit
+  rel: valueRelatedArtifact_resourceReference_Quantity
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2082,9 +2082,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2209,7 +2209,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2218,15 +2218,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  rel: valueRelatedArtifact_resourceReference_ResearchStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2235,9 +2235,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2515,7 +2515,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Met
+  rel: valueRelatedArtifact_resourceReference_Meta
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2524,9 +2524,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2583,7 +2583,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Pathw
+  rel: valueRelatedArtifact_resourceReference_Pathway
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskinput
@@ -2592,9 +2592,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:

--- a/schema/TaskInput.yaml
+++ b/schema/TaskInput.yaml
@@ -83,6 +83,2879 @@ links:
     id: /valueUsageContext/valueReference/reference
   templateRequired:
   - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Timing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SampledDat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Observation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Phenotype
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientLink
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Patient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Annotation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Substance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_UsageContext
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Allele
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Period
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Protein
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Gene
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Task
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Range
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientContact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Condition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Citation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Attachment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Mone
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Encounter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RatioRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Resource
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Procedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Distance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Methylation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Interaction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Address
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Expression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Reference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Transcript
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Availabilit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Count
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Quantit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneSet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Narrative
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Signature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Dosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Specimen
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Extension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_HumanName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Met
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Pathw
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Identifier
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskInput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Medication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Publication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Exon
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Age
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Duration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Ratio
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Coding
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskinput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
 properties:
   _valueBase64Binary:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/TaskOutput.yaml
+++ b/schema/TaskOutput.yaml
@@ -83,6 +83,2879 @@ links:
     id: /valueUsageContext/valueReference/reference
   templateRequired:
   - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministration/*
+  targetSchema:
+    $ref: MedicationAdministration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReference/*
+  targetSchema:
+    $ref: DocumentReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorship/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesPerformer/*
+  targetSchema:
+    $ref: ImagingStudySeriesPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntr/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntr.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskPerformer/*
+  targetSchema:
+    $ref: TaskPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Timing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Timing/*
+  targetSchema:
+    $ref: Timing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SampledDat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SampledDat/*
+  targetSchema:
+    $ref: SampledDat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyComparisonGroup
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyComparisonGroup/*
+  targetSchema:
+    $ref: ResearchStudyComparisonGroup.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistor/*
+  targetSchema:
+    $ref: FamilyMemberHistor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenePhenotypeAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenePhenotypeAssociation/*
+  targetSchema:
+    $ref: GenePhenotypeAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RelatedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RelatedArtifact/*
+  targetSchema:
+    $ref: RelatedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Observation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Observation/*
+  targetSchema:
+    $ref: Observation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationTriggeredB/*
+  targetSchema:
+    $ref: ObservationTriggeredB.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCode
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCode/*
+  targetSchema:
+    $ref: SubstanceDefinitionCode.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactClassification/*
+  targetSchema:
+    $ref: CitationCitedArtifactClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactAbstract
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactAbstract/*
+  targetSchema:
+    $ref: CitationCitedArtifactAbstract.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementCodeFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementCodeFilter/*
+  targetSchema:
+    $ref: DataRequirementCodeFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryParticipant/*
+  targetSchema:
+    $ref: FamilyMemberHistoryParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Phenotype
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Phenotype/*
+  targetSchema:
+    $ref: Phenotype.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientLink
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientLink/*
+  targetSchema:
+    $ref: PatientLink.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskOutput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskOutput/*
+  targetSchema:
+    $ref: TaskOutput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Patient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Patient/*
+  targetSchema:
+    $ref: Patient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionPropert/*
+  targetSchema:
+    $ref: SubstanceDefinitionPropert.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Annotation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Annotation/*
+  targetSchema:
+    $ref: Annotation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Substance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Substance/*
+  targetSchema:
+    $ref: Substance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_UsageContext
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - UsageContext/*
+  targetSchema:
+    $ref: UsageContext.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactStatusDate/*
+  targetSchema:
+    $ref: CitationCitedArtifactStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableReference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableReference/*
+  targetSchema:
+    $ref: CodeableReference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Allele
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Allele/*
+  targetSchema:
+    $ref: Allele.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinStructure/*
+  targetSchema:
+    $ref: ProteinStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequest/*
+  targetSchema:
+    $ref: MedicationRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequest
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequest/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequest.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Period
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Period/*
+  targetSchema:
+    $ref: Period.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterParticipant/*
+  targetSchema:
+    $ref: EncounterParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPart/*
+  targetSchema:
+    $ref: CitationCitedArtifactPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityNotAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityNotAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityNotAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMolecularWeight
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMolecularWeight/*
+  targetSchema:
+    $ref: SubstanceDefinitionMolecularWeight.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionParticipant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionParticipant/*
+  targetSchema:
+    $ref: ConditionParticipant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionSourceMateri/*
+  targetSchema:
+    $ref: SubstanceDefinitionSourceMateri.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CopyNumberAlteration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CopyNumberAlteration/*
+  targetSchema:
+    $ref: CopyNumberAlteration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FHIRPrimitiveExtension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FHIRPrimitiveExtension/*
+  targetSchema:
+    $ref: FHIRPrimitiveExtension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ExtendedContactDetai/*
+  targetSchema:
+    $ref: ExtendedContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementValueFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementValueFilter/*
+  targetSchema:
+    $ref: DataRequirementValueFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Protein
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Protein/*
+  targetSchema:
+    $ref: Protein.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactRelatesTo/*
+  targetSchema:
+    $ref: CitationCitedArtifactRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementSort
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementSort/*
+  targetSchema:
+    $ref: DataRequirementSort.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeries
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeries/*
+  targetSchema:
+    $ref: ImagingStudySeries.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GenomicFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GenomicFeature/*
+  targetSchema:
+    $ref: GenomicFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionRelationship
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionRelationship/*
+  targetSchema:
+    $ref: SubstanceDefinitionRelationship.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifact/*
+  targetSchema:
+    $ref: CitationCitedArtifact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatement/*
+  targetSchema:
+    $ref: MedicationStatement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Gene
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Gene/*
+  targetSchema:
+    $ref: Gene.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Task
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Task/*
+  targetSchema:
+    $ref: Task.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyAssociatedPart/*
+  targetSchema:
+    $ref: ResearchStudyAssociatedPart.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Range
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Range/*
+  targetSchema:
+    $ref: Range.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientContact
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientContact/*
+  targetSchema:
+    $ref: PatientContact.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirement
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirement/*
+  targetSchema:
+    $ref: DataRequirement.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedureFocalDevice
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedureFocalDevice/*
+  targetSchema:
+    $ref: ProcedureFocalDevice.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Condition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Condition/*
+  targetSchema:
+    $ref: Condition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AvailabilityAvailableTime
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AvailabilityAvailableTime/*
+  targetSchema:
+    $ref: AvailabilityAvailableTime.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyRecruitment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyRecruitment/*
+  targetSchema:
+    $ref: ResearchStudyRecruitment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionName/*
+  targetSchema:
+    $ref: SubstanceDefinitionName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Citation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Citation/*
+  targetSchema:
+    $ref: Citation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenCollection
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenCollection/*
+  targetSchema:
+    $ref: SpecimenCollection.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Attachment
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Attachment/*
+  targetSchema:
+    $ref: Attachment.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyProgressStatus
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyProgressStatus/*
+  targetSchema:
+    $ref: ResearchStudyProgressStatus.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationIngredient/*
+  targetSchema:
+    $ref: MedicationIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionNameOffici/*
+  targetSchema:
+    $ref: SubstanceDefinitionNameOffici.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationSummar/*
+  targetSchema:
+    $ref: CitationSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Mone
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Mone/*
+  targetSchema:
+    $ref: Mone.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestSubstitution
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestSubstitution/*
+  targetSchema:
+    $ref: MedicationRequestSubstitution.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryProcedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryProcedure/*
+  targetSchema:
+    $ref: FamilyMemberHistoryProcedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFor/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFor.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Encounter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Encounter/*
+  targetSchema:
+    $ref: Encounter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskRestriction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskRestriction/*
+  targetSchema:
+    $ref: TaskRestriction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_RatioRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - RatioRange/*
+  targetSchema:
+    $ref: RatioRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticVariant
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticVariant/*
+  targetSchema:
+    $ref: SomaticVariant.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TranscriptExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TranscriptExpression/*
+  targetSchema:
+    $ref: TranscriptExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationStatementAdherence
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationStatementAdherence/*
+  targetSchema:
+    $ref: MedicationStatementAdherence.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MethylationProbe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MethylationProbe/*
+  targetSchema:
+    $ref: MethylationProbe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneOntologyTer/*
+  targetSchema:
+    $ref: GeneOntologyTer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistoryCondition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - FamilyMemberHistoryCondition/*
+  targetSchema:
+    $ref: FamilyMemberHistoryCondition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStudySeriesInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStudySeriesInstance/*
+  targetSchema:
+    $ref: ImagingStudySeriesInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationClassification
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationClassification/*
+  targetSchema:
+    $ref: CitationClassification.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Resource
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Resource/*
+  targetSchema:
+    $ref: Resource.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneExpression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneExpression/*
+  targetSchema:
+    $ref: GeneExpression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DosageDoseAndRate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DosageDoseAndRate/*
+  targetSchema:
+    $ref: DosageDoseAndRate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationReferenceRange
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationReferenceRange/*
+  targetSchema:
+    $ref: ObservationReferenceRange.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactDetai/*
+  targetSchema:
+    $ref: ContactDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Procedure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Procedure/*
+  targetSchema:
+    $ref: Procedure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationRequestDispenseRequestInitialFi/*
+  targetSchema:
+    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyLabe/*
+  targetSchema:
+    $ref: ResearchStudyLabe.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContentProfile
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContentProfile/*
+  targetSchema:
+    $ref: DocumentReferenceContentProfile.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyObjective
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyObjective/*
+  targetSchema:
+    $ref: ResearchStudyObjective.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProcedurePerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProcedurePerformer/*
+  targetSchema:
+    $ref: ProcedurePerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubjectProgress
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubjectProgress/*
+  targetSchema:
+    $ref: ResearchSubjectProgress.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Distance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Distance/*
+  targetSchema:
+    $ref: Distance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipSummar/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipSummar.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationStatusDate
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationStatusDate/*
+  targetSchema:
+    $ref: CitationStatusDate.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ImagingStud/*
+  targetSchema:
+    $ref: ImagingStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Methylation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Methylation/*
+  targetSchema:
+    $ref: Methylation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Interaction
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Interaction/*
+  targetSchema:
+    $ref: Interaction.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SomaticCallset
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SomaticCallset/*
+  targetSchema:
+    $ref: SomaticCallset.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ObservationComponent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ObservationComponent/*
+  targetSchema:
+    $ref: ObservationComponent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Address
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Address/*
+  targetSchema:
+    $ref: Address.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructureRepresentation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructureRepresentation/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructureRepresentation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Expression
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Expression/*
+  targetSchema:
+    $ref: Expression.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceIngredient
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceIngredient/*
+  targetSchema:
+    $ref: SubstanceIngredient.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterLocation/*
+  targetSchema:
+    $ref: EncounterLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterDiagnosis
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterDiagnosis/*
+  targetSchema:
+    $ref: EncounterDiagnosis.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Reference
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Reference/*
+  targetSchema:
+    $ref: Reference.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactVersion
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactVersion/*
+  targetSchema:
+    $ref: CitationCitedArtifactVersion.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Transcript
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Transcript/*
+  targetSchema:
+    $ref: Transcript.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionMoiet/*
+  targetSchema:
+    $ref: SubstanceDefinitionMoiet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Availabilit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Availabilit/*
+  targetSchema:
+    $ref: Availabilit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Count
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Count/*
+  targetSchema:
+    $ref: Count.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Quantit
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Quantit/*
+  targetSchema:
+    $ref: Quantit.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceAttester
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceAttester/*
+  targetSchema:
+    $ref: DocumentReferenceAttester.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_GeneSet
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - GeneSet/*
+  targetSchema:
+    $ref: GeneSet.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceRelatesTo
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceRelatesTo/*
+  targetSchema:
+    $ref: DocumentReferenceRelatesTo.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Narrative
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Narrative/*
+  targetSchema:
+    $ref: Narrative.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenFeature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenFeature/*
+  targetSchema:
+    $ref: SpecimenFeature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DocumentReferenceContent
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DocumentReferenceContent/*
+  targetSchema:
+    $ref: DocumentReferenceContent.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterAdmission
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterAdmission/*
+  targetSchema:
+    $ref: EncounterAdmission.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - VirtualServiceDetai/*
+  targetSchema:
+    $ref: VirtualServiceDetai.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStud/*
+  targetSchema:
+    $ref: ResearchStud.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DataRequirementDateFilter
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DataRequirementDateFilter/*
+  targetSchema:
+    $ref: DataRequirementDateFilter.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_EncounterReason
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - EncounterReason/*
+  targetSchema:
+    $ref: EncounterReason.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Signature
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Signature/*
+  targetSchema:
+    $ref: Signature.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Dosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Dosage/*
+  targetSchema:
+    $ref: Dosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_PatientCommunication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - PatientCommunication/*
+  targetSchema:
+    $ref: PatientCommunication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Specimen
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Specimen/*
+  targetSchema:
+    $ref: Specimen.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactTitle
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactTitle/*
+  targetSchema:
+    $ref: CitationCitedArtifactTitle.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationDosage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationDosage/*
+  targetSchema:
+    $ref: MedicationAdministrationDosage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenContainer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenContainer/*
+  targetSchema:
+    $ref: SpecimenContainer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Extension
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Extension/*
+  targetSchema:
+    $ref: Extension.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFormPublishedIn
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactPublicationFormPublishedIn/*
+  targetSchema:
+    $ref: CitationCitedArtifactPublicationFormPublishedIn.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntryContributionInstance
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactContributorshipEntryContributionInstance/*
+  targetSchema:
+    $ref: CitationCitedArtifactContributorshipEntryContributionInstance.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_DrugResponse
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - DrugResponse/*
+  targetSchema:
+    $ref: DrugResponse.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_HumanName
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - HumanName/*
+  targetSchema:
+    $ref: HumanName.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionCharacterization
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionCharacterization/*
+  targetSchema:
+    $ref: SubstanceDefinitionCharacterization.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TriggerDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TriggerDefinition/*
+  targetSchema:
+    $ref: TriggerDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Met
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Met/*
+  targetSchema:
+    $ref: Met.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyOutcomeMeasure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchStudyOutcomeMeasure/*
+  targetSchema:
+    $ref: ResearchStudyOutcomeMeasure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ProteinCompoundAssociation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ProteinCompoundAssociation/*
+  targetSchema:
+    $ref: ProteinCompoundAssociation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_AlleleEffect
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - AlleleEffect/*
+  targetSchema:
+    $ref: AlleleEffect.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Pathw
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Pathw/*
+  targetSchema:
+    $ref: Pathw.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Identifier
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Identifier/*
+  targetSchema:
+    $ref: Identifier.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationAdministrationPerformer
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationAdministrationPerformer/*
+  targetSchema:
+    $ref: MedicationAdministrationPerformer.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TaskInput
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TaskInput/*
+  targetSchema:
+    $ref: TaskInput.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Medication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Medication/*
+  targetSchema:
+    $ref: Medication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_MedicationBatch
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - MedicationBatch/*
+  targetSchema:
+    $ref: MedicationBatch.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ResearchSubject
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ResearchSubject/*
+  targetSchema:
+    $ref: ResearchSubject.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Publication
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Publication/*
+  targetSchema:
+    $ref: Publication.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CodeableConcept
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CodeableConcept/*
+  targetSchema:
+    $ref: CodeableConcept.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ContactPoint
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ContactPoint/*
+  targetSchema:
+    $ref: ContactPoint.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Exon
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Exon/*
+  targetSchema:
+    $ref: Exon.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Age
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Age/*
+  targetSchema:
+    $ref: Age.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinition/*
+  targetSchema:
+    $ref: SubstanceDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ConditionStage
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ConditionStage/*
+  targetSchema:
+    $ref: ConditionStage.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Duration
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Duration/*
+  targetSchema:
+    $ref: Duration.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SpecimenProcessing
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SpecimenProcessing/*
+  targetSchema:
+    $ref: SpecimenProcessing.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionStructure
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - SubstanceDefinitionStructure/*
+  targetSchema:
+    $ref: SubstanceDefinitionStructure.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Ratio
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Ratio/*
+  targetSchema:
+    $ref: Ratio.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_ParameterDefinition
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - ParameterDefinition/*
+  targetSchema:
+    $ref: ParameterDefinition.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactWebLocation
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - CitationCitedArtifactWebLocation/*
+  targetSchema:
+    $ref: CitationCitedArtifactWebLocation.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_Coding
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - Coding/*
+  targetSchema:
+    $ref: Coding.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
+- href: id
+  rel: valueRelatedArtifact_resourceReference_TimingRepeat
+  targetHints:
+    backref:
+    - valueRelatedArtifact_resourceReference_taskoutput
+    direction:
+    - outbound
+    multiplicity:
+    - has_one
+    regex_match:
+    - TimingRepeat/*
+  targetSchema:
+    $ref: TimingRepeat.yaml
+  templatePointers:
+    id: /valueRelatedArtifact/resourceReference/reference
+  templateRequired:
+  - id
 properties:
   _valueBase64Binary:
     $ref: FHIRPrimitiveExtension.yaml

--- a/schema/TaskOutput.yaml
+++ b/schema/TaskOutput.yaml
@@ -152,7 +152,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntr
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipEntry
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -161,9 +161,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipEntr/*
+    - CitationCitedArtifactContributorshipEntry/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipEntr.yaml
+    $ref: CitationCitedArtifactContributorshipEntry.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -203,7 +203,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SampledDat
+  rel: valueRelatedArtifact_resourceReference_SampledData
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -212,9 +212,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SampledDat/*
+    - SampledData/*
   targetSchema:
-    $ref: SampledDat.yaml
+    $ref: SampledData.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -237,7 +237,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistor
+  rel: valueRelatedArtifact_resourceReference_FamilyMemberHistory
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -246,9 +246,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - FamilyMemberHistor/*
+    - FamilyMemberHistory/*
   targetSchema:
-    $ref: FamilyMemberHistor.yaml
+    $ref: FamilyMemberHistory.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -305,7 +305,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredB
+  rel: valueRelatedArtifact_resourceReference_ObservationTriggeredBy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -314,9 +314,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ObservationTriggeredB/*
+    - ObservationTriggeredBy/*
   targetSchema:
-    $ref: ObservationTriggeredB.yaml
+    $ref: ObservationTriggeredBy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -475,7 +475,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionPropert
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionProperty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -484,9 +484,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionPropert/*
+    - SubstanceDefinitionProperty/*
   targetSchema:
-    $ref: SubstanceDefinitionPropert.yaml
+    $ref: SubstanceDefinitionProperty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -747,7 +747,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMateri
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionSourceMaterial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -756,9 +756,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionSourceMateri/*
+    - SubstanceDefinitionSourceMaterial/*
   targetSchema:
-    $ref: SubstanceDefinitionSourceMateri.yaml
+    $ref: SubstanceDefinitionSourceMaterial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -798,7 +798,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetai
+  rel: valueRelatedArtifact_resourceReference_ExtendedContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -807,9 +807,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ExtendedContactDetai/*
+    - ExtendedContactDetail/*
   targetSchema:
-    $ref: ExtendedContactDetai.yaml
+    $ref: ExtendedContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1002,7 +1002,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedPart
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyAssociatedParty
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1011,9 +1011,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyAssociatedPart/*
+    - ResearchStudyAssociatedParty/*
   targetSchema:
-    $ref: ResearchStudyAssociatedPart.yaml
+    $ref: ResearchStudyAssociatedParty.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1240,7 +1240,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOffici
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionNameOfficial
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1249,15 +1249,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionNameOffici/*
+    - SubstanceDefinitionNameOfficial/*
   targetSchema:
-    $ref: SubstanceDefinitionNameOffici.yaml
+    $ref: SubstanceDefinitionNameOfficial.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationSummar
+  rel: valueRelatedArtifact_resourceReference_CitationSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1266,15 +1266,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationSummar/*
+    - CitationSummary/*
   targetSchema:
-    $ref: CitationSummar.yaml
+    $ref: CitationSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Mone
+  rel: valueRelatedArtifact_resourceReference_Money
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1283,9 +1283,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Mone/*
+    - Money/*
   targetSchema:
-    $ref: Mone.yaml
+    $ref: Money.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1325,7 +1325,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationFor
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactPublicationForm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1334,9 +1334,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactPublicationFor/*
+    - CitationCitedArtifactPublicationForm/*
   targetSchema:
-    $ref: CitationCitedArtifactPublicationFor.yaml
+    $ref: CitationCitedArtifactPublicationForm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1461,7 +1461,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_GeneOntologyTer
+  rel: valueRelatedArtifact_resourceReference_GeneOntologyTerm
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1470,9 +1470,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - GeneOntologyTer/*
+    - GeneOntologyTerm/*
   targetSchema:
-    $ref: GeneOntologyTer.yaml
+    $ref: GeneOntologyTerm.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1597,7 +1597,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ContactDetai
+  rel: valueRelatedArtifact_resourceReference_ContactDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1606,9 +1606,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ContactDetai/*
+    - ContactDetail/*
   targetSchema:
-    $ref: ContactDetai.yaml
+    $ref: ContactDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1631,7 +1631,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFi
+  rel: valueRelatedArtifact_resourceReference_MedicationRequestDispenseRequestInitialFill
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1640,15 +1640,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - MedicationRequestDispenseRequestInitialFi/*
+    - MedicationRequestDispenseRequestInitialFill/*
   targetSchema:
-    $ref: MedicationRequestDispenseRequestInitialFi.yaml
+    $ref: MedicationRequestDispenseRequestInitialFill.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabe
+  rel: valueRelatedArtifact_resourceReference_ResearchStudyLabel
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1657,9 +1657,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStudyLabe/*
+    - ResearchStudyLabel/*
   targetSchema:
-    $ref: ResearchStudyLabe.yaml
+    $ref: ResearchStudyLabel.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1750,7 +1750,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummar
+  rel: valueRelatedArtifact_resourceReference_CitationCitedArtifactContributorshipSummary
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1759,9 +1759,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - CitationCitedArtifactContributorshipSummar/*
+    - CitationCitedArtifactContributorshipSummary/*
   targetSchema:
-    $ref: CitationCitedArtifactContributorshipSummar.yaml
+    $ref: CitationCitedArtifactContributorshipSummary.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -1784,7 +1784,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ImagingStud
+  rel: valueRelatedArtifact_resourceReference_ImagingStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -1793,9 +1793,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ImagingStud/*
+    - ImagingStudy/*
   targetSchema:
-    $ref: ImagingStud.yaml
+    $ref: ImagingStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2022,7 +2022,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiet
+  rel: valueRelatedArtifact_resourceReference_SubstanceDefinitionMoiety
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2031,15 +2031,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - SubstanceDefinitionMoiet/*
+    - SubstanceDefinitionMoiety/*
   targetSchema:
-    $ref: SubstanceDefinitionMoiet.yaml
+    $ref: SubstanceDefinitionMoiety.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Availabilit
+  rel: valueRelatedArtifact_resourceReference_Availability
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2048,9 +2048,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Availabilit/*
+    - Availability/*
   targetSchema:
-    $ref: Availabilit.yaml
+    $ref: Availability.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2073,7 +2073,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Quantit
+  rel: valueRelatedArtifact_resourceReference_Quantity
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2082,9 +2082,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Quantit/*
+    - Quantity/*
   targetSchema:
-    $ref: Quantit.yaml
+    $ref: Quantity.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2209,7 +2209,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetai
+  rel: valueRelatedArtifact_resourceReference_VirtualServiceDetail
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2218,15 +2218,15 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - VirtualServiceDetai/*
+    - VirtualServiceDetail/*
   targetSchema:
-    $ref: VirtualServiceDetai.yaml
+    $ref: VirtualServiceDetail.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_ResearchStud
+  rel: valueRelatedArtifact_resourceReference_ResearchStudy
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2235,9 +2235,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - ResearchStud/*
+    - ResearchStudy/*
   targetSchema:
-    $ref: ResearchStud.yaml
+    $ref: ResearchStudy.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2515,7 +2515,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Met
+  rel: valueRelatedArtifact_resourceReference_Meta
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2524,9 +2524,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Met/*
+    - Meta/*
   targetSchema:
-    $ref: Met.yaml
+    $ref: Meta.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:
@@ -2583,7 +2583,7 @@ links:
   templateRequired:
   - id
 - href: id
-  rel: valueRelatedArtifact_resourceReference_Pathw
+  rel: valueRelatedArtifact_resourceReference_Pathway
   targetHints:
     backref:
     - valueRelatedArtifact_resourceReference_taskoutput
@@ -2592,9 +2592,9 @@ links:
     multiplicity:
     - has_one
     regex_match:
-    - Pathw/*
+    - Pathway/*
   targetSchema:
-    $ref: Pathw.yaml
+    $ref: Pathway.yaml
   templatePointers:
     id: /valueRelatedArtifact/resourceReference/reference
   templateRequired:

--- a/schemaEditTools/add_regex_match.py
+++ b/schemaEditTools/add_regex_match.py
@@ -1,0 +1,44 @@
+import os
+import yaml
+
+
+if __name__ == '__main__':
+    schema_dir = '../schema'
+    schema_files = [f for f in os.listdir(schema_dir) if str(f).endswith(".yaml")]
+    schemaNames = [scf.rstrip(".yaml") for scf in schema_files]
+    for schema in schema_files:
+        with open(f"{schema_dir}/{schema}", "r")as rf:
+            schema_data = yaml.safe_load(rf)
+            for link in schema_data["links"]:
+                if link["href"] == "Resource/{id}":
+                    with open(f"{schema}", "w") as wf:
+                        for sch in schemaNames:
+                            new_link = {
+                                "href": "id",
+                                "rel": link["rel"] + f"_{sch}",
+                                "targetHints": {
+                                    "backref": [
+                                        link["rel"] + f"_{schema_data["$id"].lower()}"
+                                    ],
+                                    "direction":
+                                        list(link["targetHints"]["direction"])
+                                    ,
+                                    "multiplicity": [
+                                        'has_one'
+                                    ],
+                                    "regex_match":[
+                                        f"{sch}/*"
+                                    ]
+                                },
+                                "targetSchema": {
+                                    "$ref": f"{sch}.yaml"
+                                },
+                                "templatePointers":{
+                                    "id": link["templatePointers"]["id"]
+                                },
+                                "templateRequired":[
+                                    "id"
+                                ]
+                            }
+                            schema_data["links"].append(new_link)
+                        yaml.dump(schema_data, wf)

--- a/schemaEditTools/add_regex_match.py
+++ b/schemaEditTools/add_regex_match.py
@@ -5,7 +5,7 @@ import yaml
 if __name__ == '__main__':
     schema_dir = '../schema'
     schema_files = [f for f in os.listdir(schema_dir) if str(f).endswith(".yaml")]
-    schemaNames = [scf.rstrip(".yaml") for scf in schema_files]
+    schemaNames = [scf.removesuffix(".yaml") for scf in schema_files]
     for schema in schema_files:
         with open(f"{schema_dir}/{schema}", "r")as rf:
             schema_data = yaml.safe_load(rf)


### PR DESCRIPTION
Add `regex_match` schema key to schema so that jsonschemagraph tool works with schemas.

ex tested command:

`jsonschemagraph  gen-dir bmeg-etl/schema META OUT` where META is a directory full of fhir like data

This action expands out the schemas since something like 
```
- href: Resource/{id}
  rel: focus
  targetHints:
    backref:
    - focus_observation
    direction:
    - outbound
    multiplicity:
    - has_many
  targetSchema:
    $ref: Resource.yaml
  templatePointers:
    id: /focus/-/reference
  templateRequired:
  - id
  ```
Now substitutes the wildcard "Resource" type with as many edges as there are vertex types in the schema. 